### PR TITLE
Feat/apple game

### DIFF
--- a/packages/snack-game/src/api/members.ts
+++ b/packages/snack-game/src/api/members.ts
@@ -5,7 +5,7 @@ const membersApi = {
   endPoint: {
     login: '/members/token',
     register: '/members',
-    guest: 'members/guests',
+    guest: 'members/guest',
 
     names: '/members/names',
   },
@@ -18,16 +18,22 @@ const membersApi = {
     const { data } = await api.post(membersApi.endPoint.login, {
       name,
     });
-    return data.accessToken;
+    return { accessToken: data.accessToken, member: data.member };
   },
 
   register: async ({ name, group }: MemberType) => {
     const { data } = await api.post(membersApi.endPoint.register, {
       name,
-      group: group?.name?.length == 0 ? null : group?.name,
+      group: group?.name ?? null,
     });
 
-    return data.accessToken;
+    return { accessToken: data.accessToken, member: data.member };
+  },
+
+  guest: async () => {
+    const { data } = await api.post(membersApi.endPoint.guest);
+
+    return { accessToken: data.accessToken, member: data.member };
   },
 };
 

--- a/packages/snack-game/src/components/games/AppleGame.tsx
+++ b/packages/snack-game/src/components/games/AppleGame.tsx
@@ -19,10 +19,9 @@ interface AppleGameProps {
 const AppleGame = ({ clientWidth, clientHeight }: AppleGameProps) => {
   const [apples, setApples] = useState<Apple[]>([]);
   const [removedApples, setRemovedApples] = useState<Apple[]>([]);
-  const [score, setScore] = useState<number>(0);
   const [start, setStart] = useState<boolean>(false);
   const [rect, setRect] = useState<DOMRect>();
-  const { gameStartMutate } = useGameStart();
+  const { gameStart, error } = useGameStart();
 
   const drag: Drag = new Drag();
   const appleGameManager: AppleGameManager = new AppleGameManager();
@@ -105,9 +104,11 @@ const AppleGame = ({ clientWidth, clientHeight }: AppleGameProps) => {
 
   const handleStartButton = () => {
     if (rect) {
-      setApples(appleGameManager.generateApples(rect));
-      setStart(true);
-      gameStartMutate();
+      gameStart();
+      if (!error) {
+        setApples(appleGameManager.generateApples(rect));
+        setStart(true);
+      }
     }
   };
 

--- a/packages/snack-game/src/components/ui/Header/Header.tsx
+++ b/packages/snack-game/src/components/ui/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 
+import { css } from '@emotion/react';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
 
 import LogoImage from '@assets/images/logo.png';
@@ -10,12 +11,20 @@ import theme from '@utils/theme';
 
 import PATH from '@constants/path.constant';
 import { TOAST_MESSAGE } from '@constants/toast.constant';
+import useLocalStorage from '@hooks/useLocalStorage';
 import useToast from '@hooks/useToast';
 
 const Header = () => {
   const userInfo = useRecoilValue(userState);
   const resetUser = useResetRecoilState(resetUserState);
+  const { deleteStorageValue } = useLocalStorage({ key: 'accessToken' });
   const openToast = useToast();
+
+  const handleLogout = () => {
+    resetUser();
+    deleteStorageValue();
+    openToast(TOAST_MESSAGE.AUTH_LOGOUT, 'success');
+  };
 
   return (
     <Styled.HeaderContainer>
@@ -29,14 +38,12 @@ const Header = () => {
         </Link>
         {userInfo.accessToken ? (
           <>
-            {userInfo.name} 님{' '}
+            {userInfo.name} 님
             <Button
+              wrapper={css({ marginLeft: '0.5rem' })}
               content={'로그아웃'}
               size={'small'}
-              onClick={() => {
-                resetUser();
-                openToast(TOAST_MESSAGE.AUTH_LOGOUT, 'success');
-              }}
+              onClick={handleLogout}
             />
           </>
         ) : (

--- a/packages/snack-game/src/constants/toast.constant.ts
+++ b/packages/snack-game/src/constants/toast.constant.ts
@@ -8,6 +8,8 @@ export const TOAST_MESSAGE = {
 
   // AUTH
   AUTH_LOGIN: '로그인 되었습니다!',
+  AUTH_REGISTER: '회원가입 완료!',
+  AUTH_GUEST: '게스트로 로그인 되었습니다!',
   AUTH_LOGOUT: '로그아웃 되었습니다!',
   AUTH_ERROR: '로그인에 실패하였습니다!',
   AUTH_ERROR_NOT_FOUND: '존재하지 않는 사용자입니다!',

--- a/packages/snack-game/src/hooks/queries/members.query.ts
+++ b/packages/snack-game/src/hooks/queries/members.query.ts
@@ -5,7 +5,7 @@ import { useSetRecoilState } from 'recoil';
 
 import membersApi from '@api/members';
 import { userState } from '@utils/atoms/auth';
-import { MemberType } from '@utils/types/member.type';
+import { AuthType, MemberType } from '@utils/types/member.type';
 
 import { ServerError } from '@constants/api.constant';
 import LOCAL_STORAGE from '@constants/localstorage.constant';
@@ -16,48 +16,71 @@ import { useInternalRouter } from '@hooks/useInternalRouter';
 import useLocalStorage from '@hooks/useLocalStorage';
 import useToast from '@hooks/useToast';
 
-export const useMemberAuth = (
-  apiMethod: (member: MemberType) => Promise<string>,
+interface useMemberAuthProps {
+  apiMethod: (member: MemberType) => Promise<AuthType>;
+  message: string;
+}
+
+const useMemberMutation = <T>(
+  apiMethod: (args: T) => Promise<AuthType>,
+  onSuccess: (data: AuthType) => void,
 ) => {
-  const openToast = useToast();
   const errorPopup = useError();
+  return useMutation<AuthType, AxiosError<ServerError>, T>(apiMethod, {
+    retry: 0,
+    onError: (error: AxiosError<ServerError>) => {
+      if (error.response) {
+        if (error.response.status >= 500) {
+          throw error;
+        }
+        errorPopup(error.response.status, error.response.data.messages);
+      }
+    },
+    onSuccess,
+  });
+};
+
+const useMemberOnSuccess = (message: string, redirect?: string) => {
+  const openToast = useToast();
   const setUserState = useSetRecoilState(userState);
-  const router = useInternalRouter();
   const { setStorageValue } = useLocalStorage({
     key: LOCAL_STORAGE.ACCESS_TOKEN,
   });
+  const router = useInternalRouter();
 
-  const { mutate } = useMutation<string, AxiosError<ServerError>, MemberType>(
-    apiMethod,
-    {
-      retry: 0,
-      onError: (error: AxiosError<ServerError>) => {
-        if (error.response) {
-          if (error.response.status >= 500) {
-            throw error;
-          }
-
-          errorPopup(error.response.status, error.response.data.messages);
-        }
-      },
-      onSuccess: (accessToken: string, context: MemberType) => {
-        setStorageValue(accessToken);
-        setUserState(() => ({
-          id: context.id,
-          name: context.name,
-          group: context.group,
-          accessToken,
-        }));
-        openToast(TOAST_MESSAGE.AUTH_LOGIN, 'success');
-        router.push(PATH.HOME);
-      },
-    },
-  );
-
-  return {
-    authMutate: mutate,
+  return ({ accessToken, member }: AuthType) => {
+    setStorageValue(accessToken);
+    setUserState(() => ({
+      id: member.id,
+      name: member.name,
+      group: member.group,
+      accessToken,
+    }));
+    openToast(message, 'success');
+    if (redirect) router.push(redirect);
   };
 };
 
-export const useMemberRegister = () => useMemberAuth(membersApi.register);
-export const useMemberLogin = () => useMemberAuth(membersApi.login);
+export const useMemberAuth = ({ apiMethod, message }: useMemberAuthProps) => {
+  const onSuccess = useMemberOnSuccess(message, PATH.HOME);
+  const { mutate } = useMemberMutation(apiMethod, onSuccess);
+  return { authMutate: mutate };
+};
+
+export const useMemberGuest = () => {
+  const onSuccess = useMemberOnSuccess(TOAST_MESSAGE.AUTH_GUEST);
+  const { mutate } = useMemberMutation(membersApi.guest, onSuccess);
+  return { guestMutate: mutate };
+};
+
+export const useMemberRegister = () =>
+  useMemberAuth({
+    apiMethod: membersApi.register,
+    message: TOAST_MESSAGE.AUTH_REGISTER,
+  });
+
+export const useMemberLogin = () =>
+  useMemberAuth({
+    apiMethod: membersApi.login,
+    message: TOAST_MESSAGE.AUTH_LOGIN,
+  });

--- a/packages/snack-game/src/hooks/queries/members.query.ts
+++ b/packages/snack-game/src/hooks/queries/members.query.ts
@@ -21,7 +21,7 @@ interface useMemberAuthProps {
   message: string;
 }
 
-const useMemberMutation = <T>(
+const useMemberMutation = <T = void>(
   apiMethod: (args: T) => Promise<AuthType>,
   onSuccess: (data: AuthType) => void,
 ) => {

--- a/packages/snack-game/src/hooks/queries/members.query.ts
+++ b/packages/snack-game/src/hooks/queries/members.query.ts
@@ -21,7 +21,7 @@ interface useMemberAuthProps {
   message: string;
 }
 
-const useMemberMutation = <T = void>(
+const useMemberMutation = <T>(
   apiMethod: (args: T) => Promise<AuthType>,
   onSuccess: (data: AuthType) => void,
 ) => {
@@ -63,13 +63,13 @@ const useMemberOnSuccess = (message: string, redirect?: string) => {
 
 export const useMemberAuth = ({ apiMethod, message }: useMemberAuthProps) => {
   const onSuccess = useMemberOnSuccess(message, PATH.HOME);
-  const { mutate } = useMemberMutation(apiMethod, onSuccess);
+  const { mutate } = useMemberMutation<MemberType>(apiMethod, onSuccess);
   return { authMutate: mutate };
 };
 
 export const useMemberGuest = () => {
   const onSuccess = useMemberOnSuccess(TOAST_MESSAGE.AUTH_GUEST);
-  const { mutate } = useMemberMutation(membersApi.guest, onSuccess);
+  const { mutate } = useMemberMutation<void>(membersApi.guest, onSuccess);
   return { guestMutate: mutate };
 };
 

--- a/packages/snack-game/src/hooks/queries/members.query.ts
+++ b/packages/snack-game/src/hooks/queries/members.query.ts
@@ -1,5 +1,4 @@
 import { useMutation } from 'react-query';
-import { useNavigate } from 'react-router-dom';
 
 import { AxiosError } from 'axios';
 import { useSetRecoilState } from 'recoil';
@@ -13,6 +12,7 @@ import LOCAL_STORAGE from '@constants/localstorage.constant';
 import PATH from '@constants/path.constant';
 import { TOAST_MESSAGE } from '@constants/toast.constant';
 import useError from '@hooks/useError';
+import { useInternalRouter } from '@hooks/useInternalRouter';
 import useLocalStorage from '@hooks/useLocalStorage';
 import useToast from '@hooks/useToast';
 
@@ -21,8 +21,8 @@ export const useMemberAuth = (
 ) => {
   const openToast = useToast();
   const errorPopup = useError();
-  const navigate = useNavigate();
   const setUserState = useSetRecoilState(userState);
+  const router = useInternalRouter();
   const { setStorageValue } = useLocalStorage({
     key: LOCAL_STORAGE.ACCESS_TOKEN,
   });
@@ -49,7 +49,7 @@ export const useMemberAuth = (
           accessToken,
         }));
         openToast(TOAST_MESSAGE.AUTH_LOGIN, 'success');
-        navigate(PATH.HOME);
+        router.push(PATH.HOME);
       },
     },
   );

--- a/packages/snack-game/src/hooks/useInternalRouter.ts
+++ b/packages/snack-game/src/hooks/useInternalRouter.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export function useInternalRouter() {
+  const navigate = useNavigate();
+
+  return useMemo(() => {
+    return {
+      goBack() {
+        navigate(-1);
+      },
+      push(path: RoutePath) {
+        navigate(path);
+      },
+      replace(path: RoutePath) {
+        navigate(path, { replace: true });
+      },
+    };
+  }, [navigate]);
+}
+
+type RoutePath = string;

--- a/packages/snack-game/src/modules/snackRainManager.ts
+++ b/packages/snack-game/src/modules/snackRainManager.ts
@@ -6,6 +6,16 @@ import CookieImage from '@assets/images/cookie.png';
 import JellyImage from '@assets/images/jelly.png';
 import OrangeImage from '@assets/images/orange.png';
 
+const imageSet = [
+  CandyImage,
+  CandyCaneImage,
+  AppleImage,
+  OrangeImage,
+  JellyImage,
+  CookieImage,
+  ChocolateImage,
+];
+
 interface Unit {
   x: number;
   y: number;
@@ -32,15 +42,6 @@ interface Settings {
 export class SnackRainManager {
   private readonly units: Unit[];
   private settings: Settings;
-  private images = [
-    CandyImage,
-    CandyCaneImage,
-    AppleImage,
-    OrangeImage,
-    JellyImage,
-    CookieImage,
-    ChocolateImage,
-  ];
 
   constructor() {
     this.units = [];
@@ -74,8 +75,7 @@ export class SnackRainManager {
       image: new Image(),
     };
 
-    unit.image.src =
-      this.images[Math.floor(Math.random() * this.images.length)];
+    unit.image.src = imageSet[Math.floor(Math.random() * imageSet.length)];
 
     this.units.push(unit);
   }
@@ -96,8 +96,6 @@ export class SnackRainManager {
     });
 
     for (const idx in this.units) {
-      let collapsed = false;
-
       const unit = this.units[idx];
       const afterUnitPosition = {
         x: unit.x + unit.velocity.x,
@@ -123,8 +121,6 @@ export class SnackRainManager {
           const sumRadius = item.radius + unit.radius;
 
           if (distanceUnits < sumRadius) {
-            collapsed = true;
-
             const afterVelocity1 = this.getVelocity(unit, item);
             const afterVelocity2 = this.getVelocity(item, unit);
 

--- a/packages/snack-game/src/utils/atoms/auth.ts
+++ b/packages/snack-game/src/utils/atoms/auth.ts
@@ -20,7 +20,6 @@ export const userState = atom<MemberType>({
     },
     accessToken: '',
     bestScore: 0,
-    role: undefined,
   },
   effects_UNSTABLE: [presistAtomUser],
 });

--- a/packages/snack-game/src/utils/types/member.type.ts
+++ b/packages/snack-game/src/utils/types/member.type.ts
@@ -1,13 +1,15 @@
-type MemberRoleType = 'admin' | 'user' | 'guest';
-
 export interface MemberType {
   id?: number;
-  name: string;
+  name?: string;
   group?: {
     id?: number;
     name: string | null;
   };
   accessToken?: string;
   bestScore?: number;
-  role?: MemberRoleType;
+}
+
+export interface AuthType {
+  member: MemberType;
+  accessToken: string;
 }


### PR DESCRIPTION
# 기존 로그인 로직에 Guest 추가하기

* 기존 로그인, 회원가입 로직은 같은 api만 다르고 같은 동작을 수행하기 때문에 수행할 api만 따로 넘겨주는 구조
  * useMemberAuth 이라는 hook을
    ```typescript
    export const useMemberRegister = () => useMemberAuth(membersApi.register);
    ```
    이런식으로 mutationFn을 넘겨 사용하는 방식

## 문제점 발생

* 두 api는 동작도 같고 전달해야할 파라미터도 같아 이런식의 병합이 가능했지만 guest로그인의 경우 전달할 파라미터가 없어야함
* `useMemberAuth`의 타입을 `apiMethod: (member?: MemberType) => Promise<AuthType>;`이런식으로 변경하면 기존 api들의 타입을 변경해줘야 함
*  이는 반드시 name이라는 값이 있어야하는 api에 없어도 괜찮다는 띠용한 상황 발생
```typescript
  login: async ({ name }: MemberType = {}) => {
    const { data } = await api.post(membersApi.endPoint.login, {
      name,
    });
    return { accessToken: data.accessToken, member: data.member };
  },
```
* 완전 따로 useMemberGuest hook을 만드는건 커다란 중복 코드를 남기는 상황이 생김

## 해결방법
* 성공한 경우 라우팅을 한다는 부분만 다르니 `useMemberSuccess` hook을 작성
```typescript
const useMemberOnSuccess = (message: string, redirect?: string) => {
  const openToast = useToast();
  const setUserState = useSetRecoilState(userState);
  const { setStorageValue } = useLocalStorage({
    key: LOCAL_STORAGE.ACCESS_TOKEN,
  });
  const router = useInternalRouter();

  return ({ accessToken, member }: AuthType) => {
    setStorageValue(accessToken);
    setUserState(() => ({
      id: member.id,
      name: member.name,
      group: member.group,
      accessToken,
    }));
    openToast(message, 'success');
    if (redirect) router.push(redirect);
  };
};
```
* 위에서 작성한 `useMemberOnSuccess`메시지와 라우팅 경로를 설정해 `useMemberAuth`로 넘긴다 
```typescript
export const useMemberAuth = ({ apiMethod, message }: useMemberAuthProps) => {
  const onSuccess = useMemberOnSuccess(message, PATH.HOME);
  const { mutate } = useMemberMutation<MemberType>(apiMethod, onSuccess);
  return { authMutate: mutate };
};

export const useMemberGuest = () => {
  const onSuccess = useMemberOnSuccess(TOAST_MESSAGE.AUTH_GUEST);
  const { mutate } = useMemberMutation<void>(membersApi.guest, onSuccess);
  return { guestMutate: mutate };
};


export const useMemberRegister = () =>
  useMemberAuth({
    apiMethod: membersApi.register,
    message: TOAST_MESSAGE.AUTH_REGISTER,
  });

export const useMemberLogin = () =>
  useMemberAuth({
    apiMethod: membersApi.login,
    message: TOAST_MESSAGE.AUTH_LOGIN,
  });
```
* mutation을 호출하고 에러를 핸들링하는 공통적인 로직이 들어있는데 제너릭 타입을 통해서 `apiMethod`의 파라미터 타입을 정함 guest 같이 비어있는 요청의 경우 `<void>`
```typescript
const useMemberMutation = <T = void>(
  apiMethod: (args: T) => Promise<AuthType>,
  onSuccess: (data: AuthType) => void,
) => {
  const errorPopup = useError();
  return useMutation<AuthType, AxiosError<ServerError>, T>(apiMethod, {
    retry: 0,
    onError: (error: AxiosError<ServerError>) => {
      if (error.response) {
        if (error.response.status >= 500) {
          throw error;
        }
        errorPopup(error.response.status, error.response.data.messages);
      }
    },
    onSuccess,
  });
};
```


#14 