### PR TITLE
feat: Member 타입 수정

### DIFF
--- a/packages/snack-game/src/api/auth.api.ts
+++ b/packages/snack-game/src/api/auth.api.ts
@@ -1,5 +1,5 @@
 import api from '@api/index';
-import { AuthType, MemberType } from '@utils/types/member.type';
+import { MemberType } from '@utils/types/member.type';
 
 const authApi = {
   endPoint: {
@@ -9,29 +9,29 @@ const authApi = {
     social: '/tokens/social',
   },
 
-  login: async ({ name }: MemberType): Promise<AuthType> => {
+  login: async ({ member }: MemberType): Promise<MemberType> => {
     const { data } = await api.post(authApi.endPoint.login, {
-      name,
+      name: member.name,
     });
     return { accessToken: data.accessToken, member: data.member };
   },
 
-  register: async ({ name, group }: MemberType): Promise<AuthType> => {
+  register: async ({ member }: MemberType): Promise<MemberType> => {
     const { data } = await api.post(authApi.endPoint.register, {
-      name,
-      group: group?.name,
+      name: member.name,
+      group: member.group?.name,
     });
 
     return { accessToken: data.accessToken, member: data.member };
   },
 
-  guest: async (): Promise<AuthType> => {
+  guest: async (): Promise<MemberType> => {
     const { data } = await api.post(authApi.endPoint.guest);
 
     return { accessToken: data.accessToken, member: data.member };
   },
 
-  social: async (): Promise<AuthType> => {
+  social: async (): Promise<MemberType> => {
     const { data } = await api.post(
       authApi.endPoint.social,
       {},

--- a/packages/snack-game/src/api/members.api.ts
+++ b/packages/snack-game/src/api/members.api.ts
@@ -1,5 +1,5 @@
 import api from '@api/index';
-import { AuthType } from '@utils/types/member.type';
+import { MemberType } from '@utils/types/member.type';
 
 const membersApi = {
   endPoint: {
@@ -12,7 +12,7 @@ const membersApi = {
     return await api.put(membersApi.endPoint.changeMemberName, { name });
   },
 
-  integrateMember: async (): Promise<AuthType> => {
+  integrateMember: async (): Promise<MemberType> => {
     const { data } = await api.post(
       membersApi.endPoint.integrateMember,
       {},

--- a/packages/snack-game/src/components/ui/AuthForm/LoginForm.tsx
+++ b/packages/snack-game/src/components/ui/AuthForm/LoginForm.tsx
@@ -28,7 +28,7 @@ const LoginForm = () => {
 
   const handleOnSubmit = (e: FormEvent) => {
     e.preventDefault();
-    loginMutate.mutate({ name: values.name.value, group: null });
+    loginMutate.mutate({ member: { name: values.name.value, group: null } });
   };
 
   return (

--- a/packages/snack-game/src/components/ui/AuthForm/OAuthHandler.tsx
+++ b/packages/snack-game/src/components/ui/AuthForm/OAuthHandler.tsx
@@ -16,7 +16,7 @@ const OAuthHandler = () => {
   const oAuthToken = useSocial();
 
   const handleOAuthLogin = async () => {
-    if (userStateValue.guest && userStateValue.accessToken) {
+    if (userStateValue.member.type == 'GUEST' && userStateValue.accessToken) {
       await integrateMember.mutateAsync();
     } else {
       await oAuthToken.mutateAsync();

--- a/packages/snack-game/src/components/ui/AuthForm/RegisterForm.tsx
+++ b/packages/snack-game/src/components/ui/AuthForm/RegisterForm.tsx
@@ -33,8 +33,10 @@ const RegisterForm = () => {
   const handleOnSubmit = (e: FormEvent) => {
     e.preventDefault();
     registerMutate.mutate({
-      name: values.name.value,
-      group: { name: values.group.value } || null,
+      member: {
+        name: values.name.value,
+        group: { name: values.group.value } || null,
+      },
     });
   };
 

--- a/packages/snack-game/src/components/ui/GameResult/GameResult.tsx
+++ b/packages/snack-game/src/components/ui/GameResult/GameResult.tsx
@@ -33,7 +33,7 @@ const GameResult = ({ score, reStart }: GameResultProps) => {
         <p>최종 점수: {score}점!</p>
         <Button content={'다시하기'} onClick={handleReStartButton} />
       </div>
-      {userStateValue.guest && (
+      {userStateValue.member.type === 'GUEST' && (
         <Styled.SocialLoginContainer>
           <p>나는 몇 등일까?</p>
           <RankingContainer>

--- a/packages/snack-game/src/components/ui/Header/Header.tsx
+++ b/packages/snack-game/src/components/ui/Header/Header.tsx
@@ -64,7 +64,7 @@ const Header = () => {
         {userInfo.accessToken ? (
           <>
             <Styled.Desktop>
-              <Menu buttonContent={userInfo.name + ' 님'}>
+              <Menu buttonContent={userInfo.member.name + ' 님'}>
                 <Link to={PATH.USER}>
                   <DropDownItem>내 정보</DropDownItem>
                 </Link>
@@ -72,7 +72,7 @@ const Header = () => {
               </Menu>
             </Styled.Desktop>
             <Styled.Mobile>
-              <Menu buttonContent={userInfo.name + ' 님'}>
+              <Menu buttonContent={userInfo.member.name + ' 님'}>
                 <Link to={PATH.USER}>
                   <DropDownItem>내 정보</DropDownItem>
                 </Link>

--- a/packages/snack-game/src/components/ui/RankingTable/RankingTable.tsx
+++ b/packages/snack-game/src/components/ui/RankingTable/RankingTable.tsx
@@ -21,10 +21,10 @@ const RankingTable = () => {
         })}
       </TopRankingCardWrapper>
       <Table tableTitle={tableTitle}>
-        {otherRanking?.map((item, index) => {
+        {otherRanking?.map((item) => {
           return (
             <RankingTableItem
-              key={index + 3}
+              key={item.rank}
               rank={item.rank}
               name={item.owner.name}
               group={item.owner.group}

--- a/packages/snack-game/src/components/ui/UserInfo/UserInfo.tsx
+++ b/packages/snack-game/src/components/ui/UserInfo/UserInfo.tsx
@@ -108,10 +108,12 @@ const UserInfo = () => {
           <>
             <h1>내 정보</h1>
             <InfoContainer>
-              <p>이름: {userStateValue.name}</p>
+              <p>이름: {userStateValue.member.name}</p>
               <p>
                 그룹:
-                {userStateValue.group ? userStateValue.group.name : '없음'}
+                {userStateValue.member.group
+                  ? userStateValue.member.group.name
+                  : '없음'}
               </p>
               {userRanking && (
                 <>

--- a/packages/snack-game/src/hooks/game/useAppleGameController.tsx
+++ b/packages/snack-game/src/hooks/game/useAppleGameController.tsx
@@ -27,7 +27,7 @@ const useAppleGameController = () => {
   const drag = useMemo(() => new Drag(), []);
   const appleGameManager = useMemo(() => new AppleGameManager(), []);
   const [start, setStart] = useState<boolean>(false);
-  const [timeRemaining, setTimeRemaining] = useState<number>(10);
+  const [timeRemaining, setTimeRemaining] = useState<number>(120);
 
   const { gameEnd } = useAppleGameCheck();
   const { gameStart, gameStartMutation } = useAppleGameStart();
@@ -42,7 +42,7 @@ const useAppleGameController = () => {
     await gameStart();
 
     setStart(true);
-    setTimeRemaining(10);
+    setTimeRemaining(120);
 
     if (gameHUDRef.current) {
       gameHUDRef.current.scrollIntoView({ behavior: 'smooth' });

--- a/packages/snack-game/src/hooks/game/useAppleGameController.tsx
+++ b/packages/snack-game/src/hooks/game/useAppleGameController.tsx
@@ -27,7 +27,7 @@ const useAppleGameController = () => {
   const drag = useMemo(() => new Drag(), []);
   const appleGameManager = useMemo(() => new AppleGameManager(), []);
   const [start, setStart] = useState<boolean>(false);
-  const [timeRemaining, setTimeRemaining] = useState<number>(120);
+  const [timeRemaining, setTimeRemaining] = useState<number>(10);
 
   const { gameEnd } = useAppleGameCheck();
   const { gameStart, gameStartMutation } = useAppleGameStart();
@@ -42,7 +42,7 @@ const useAppleGameController = () => {
     await gameStart();
 
     setStart(true);
-    setTimeRemaining(120);
+    setTimeRemaining(10);
 
     if (gameHUDRef.current) {
       gameHUDRef.current.scrollIntoView({ behavior: 'smooth' });

--- a/packages/snack-game/src/hooks/queries/appleGame.query.ts
+++ b/packages/snack-game/src/hooks/queries/appleGame.query.ts
@@ -10,7 +10,7 @@ import {
   appleGameProgressType,
   appleGameStateType,
 } from '@utils/types/game.type';
-import { AuthType } from '@utils/types/member.type';
+import { MemberType } from '@utils/types/member.type';
 
 import { ServerError } from '@constants/api.constant';
 import { TOAST_MESSAGE } from '@constants/toast.constant';
@@ -51,7 +51,7 @@ export const useAppleGameStart = () => {
 
   const gameStart = async () => {
     if (!userStateValue.accessToken) {
-      const { accessToken }: AuthType = await guestMutation.mutateAsync();
+      const { accessToken }: MemberType = await guestMutation.mutateAsync();
       await gameStartMutation.mutateAsync(accessToken);
     } else {
       await gameStartMutation.mutateAsync();

--- a/packages/snack-game/src/hooks/queries/auth.query.ts
+++ b/packages/snack-game/src/hooks/queries/auth.query.ts
@@ -5,7 +5,7 @@ import { useSetRecoilState } from 'recoil';
 
 import authApi from '@api/auth.api';
 import { userState } from '@utils/atoms/member.atom';
-import { AuthType, MemberType } from '@utils/types/member.type';
+import { MemberType } from '@utils/types/member.type';
 
 import { ServerError } from '@constants/api.constant';
 import { TOAST_MESSAGE } from '@constants/toast.constant';
@@ -14,7 +14,7 @@ import useOnError from '@hooks/useOnError';
 import useToast from '@hooks/useToast';
 
 interface useMemberAuthProps {
-  apiMethod: (member: MemberType) => Promise<AuthType>;
+  apiMethod: (member: MemberType) => Promise<MemberType>;
   message: string;
 }
 
@@ -28,12 +28,9 @@ const useMemberOnSuccess = ({ message, guest }: useMemberOnSuccessProps) => {
   const setUserState = useSetRecoilState(userState);
   const { closeModal } = useModal();
 
-  return ({ accessToken, member }: AuthType) => {
+  return ({ accessToken, member }: MemberType) => {
     setUserState(() => ({
-      id: member.id,
-      name: member.name,
-      group: member.group,
-      guest,
+      member,
       accessToken,
     }));
     openToast(message, 'success');
@@ -41,7 +38,7 @@ const useMemberOnSuccess = ({ message, guest }: useMemberOnSuccessProps) => {
   };
 };
 
-const userMemberErrorBoundary = (error: AxiosError<ServerError>) => {
+const memberErrorBoundary = (error: AxiosError<ServerError>) => {
   if (!error.response) throw error;
 
   return error.response?.status >= 500;
@@ -54,7 +51,7 @@ export const useMemberAuth = ({ apiMethod, message }: useMemberAuthProps) => {
     mutationFn: apiMethod,
     onSuccess,
     onError: useOnError(),
-    useErrorBoundary: userMemberErrorBoundary,
+    useErrorBoundary: memberErrorBoundary,
   });
 };
 
@@ -66,7 +63,7 @@ export const useGuest = () => {
       guest: true,
     }),
     onError: useOnError(),
-    useErrorBoundary: userMemberErrorBoundary,
+    useErrorBoundary: memberErrorBoundary,
   });
 };
 

--- a/packages/snack-game/src/hooks/queries/members.query.ts
+++ b/packages/snack-game/src/hooks/queries/members.query.ts
@@ -5,7 +5,7 @@ import { useSetRecoilState } from 'recoil';
 
 import membersApi from '@api/members.api';
 import { userState } from '@utils/atoms/member.atom';
-import { AuthType } from '@utils/types/member.type';
+import { MemberType } from '@utils/types/member.type';
 
 import { ServerError } from '@constants/api.constant';
 import { TOAST_MESSAGE } from '@constants/toast.constant';
@@ -35,7 +35,7 @@ export const useIntegrateMember = () => {
 
   return useMutation({
     mutationFn: membersApi.integrateMember,
-    onSuccess: ({ accessToken, member }: AuthType) => {
+    onSuccess: ({ accessToken, member }: MemberType) => {
       setUserState(() => ({
         member,
         accessToken,

--- a/packages/snack-game/src/hooks/queries/members.query.ts
+++ b/packages/snack-game/src/hooks/queries/members.query.ts
@@ -37,10 +37,8 @@ export const useIntegrateMember = () => {
     mutationFn: membersApi.integrateMember,
     onSuccess: ({ accessToken, member }: AuthType) => {
       setUserState(() => ({
-        id: member.id,
-        name: member.name,
-        group: member.group,
-        accessToken: accessToken,
+        member,
+        accessToken,
       }));
       openToast(TOAST_MESSAGE.AUTH_SOCIAL, 'success');
     },

--- a/packages/snack-game/src/pages/ranking/RankingPage.tsx
+++ b/packages/snack-game/src/pages/ranking/RankingPage.tsx
@@ -32,7 +32,7 @@ const RankingPage = () => {
           <QueryBoundary errorFallback={RetryError}>
             <RankingTable />
           </QueryBoundary>
-          {userStateValue.name && (
+          {userStateValue.member.name && (
             <QueryBoundary errorFallback={UserRankingCardError}>
               <UserRankingCard />
             </QueryBoundary>

--- a/packages/snack-game/src/utils/atoms/member.atom.ts
+++ b/packages/snack-game/src/utils/atoms/member.atom.ts
@@ -12,8 +12,10 @@ const { persistAtom: persistAtomUser } = recoilPersist({
 export const userState = atom<MemberType>({
   key: ATOM_KEY.USER,
   default: {
-    name: '',
-    group: null,
+    member: {
+      name: '',
+      group: null,
+    },
   },
   effects_UNSTABLE: [persistAtomUser],
 });

--- a/packages/snack-game/src/utils/types/member.type.ts
+++ b/packages/snack-game/src/utils/types/member.type.ts
@@ -3,15 +3,15 @@ export interface GroupType {
   name: string;
 }
 
-export interface MemberType {
-  id?: number;
-  name?: string;
-  group: GroupType | null;
-  guest?: boolean;
-  accessToken?: string;
-}
+export type AuthType = 'SOCIAL' | 'GUEST' | 'SELF';
 
-export interface AuthType {
-  member: MemberType;
-  accessToken: string;
+export interface MemberType {
+  member: {
+    id?: number;
+    name?: string;
+    group: GroupType | null;
+    guest?: boolean;
+    type?: AuthType;
+  };
+  accessToken?: string;
 }


### PR DESCRIPTION
# Membmer 
```typescript
export interface MemberType {
  id?: number;
  name?: string;
  group: GroupType | null;
  guest?: boolean;
  accessToken?: string;
}

export interface AuthType {
  member: MemberType;
  accessToken: string;
}
```
* 불필요하게 나누어진 MemberType을 통합
```typescript
export type AuthType = 'SOCIAL' | 'GUEST' | 'SELF';

export interface MemberType {
  member: {
    id?: number;
    name?: string;
    group: GroupType | null;
    guest?: boolean;
    type?: AuthType;
  };
  accessToken?: string;
}
```
* 서비스 요구사항 변경에 따른 계정 타입 정보 추가 AuthType
