### PR TITLE
feat: header 반응형으로 수정

### DIFF
--- a/src/assets/icon/hamburger.svg
+++ b/src/assets/icon/hamburger.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    
+    <title>hamburger</title>
+    <desc>Created with Sketch Beta.</desc>
+    <defs>
+
+</defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Icon-Set-Filled" transform="translate(-212.000000, -888.000000)" fill="currentColor">
+            <path d="M230,904 L214,904 C212.896,904 212,904.896 212,906 C212,907.104 212.896,908 214,908 L230,908 C231.104,908 232,907.104 232,906 C232,904.896 231.104,904 230,904 L230,904 Z M230,896 L214,896 C212.896,896 212,896.896 212,898 C212,899.104 212.896,900 214,900 L230,900 C231.104,900 232,899.104 232,898 C232,896.896 231.104,896 230,896 L230,896 Z M214,892 L230,892 C231.104,892 232,891.104 232,890 C232,888.896 231.104,888 230,888 L214,888 C212.896,888 212,888.896 212,890 C212,891.104 212.896,892 214,892 L214,892 Z" id="hamburger" fill="currentColor">
+
+</path>
+        </g>
+    </g>
+</svg>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,11 +1,14 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { motion } from 'framer-motion';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
 
+import Hamburger from '@assets/icon/hamburger.svg?react';
 import Auth from '@components/Auth/Auth';
 import Button from '@components/Button/Button';
 import RouterLink from '@components/RouterLink/RouterLink';
+import Spacing from '@components/Spacing/Spacing';
 import { resetUserState, userState } from '@utils/atoms/member.atom';
 
 import PATH from '@constants/path.constant';
@@ -14,15 +17,16 @@ import useToast from '@hooks/useToast';
 
 interface HeaderProps {
   className?: string;
-  nav?: ReactNode;
+  children?: ReactNode;
 }
 
-const Header = ({ nav, className }: HeaderProps) => {
+const Header = ({ children, className }: HeaderProps) => {
   const { openModal } = useModal();
   const openToast = useToast();
   const resetUser = useResetRecoilState(resetUserState);
   const userInfo = useRecoilValue(userState);
   const navigate = useNavigate();
+  const [isToggleOpen, setIsToggleOpen] = useState(false);
 
   const handleLogin = () => {
     openModal({ children: <Auth /> });
@@ -34,16 +38,29 @@ const Header = ({ nav, className }: HeaderProps) => {
     navigate(PATH.MAIN, { replace: true });
   };
 
+  const handleOpenToggle = () => {
+    setIsToggleOpen(!isToggleOpen);
+  };
+
   return (
     <header className={`z-50 w-full bg-white shadow-md ${className}`}>
-      <div className={'mx-auto flex h-16 max-w-7xl items-center px-4 lg:px-6'}>
-        <RouterLink to={'/'} hover={false} className={'flex flex-1'}>
-          <span className={'ml-2 text-2xl text-primary'}>Snack Game</span>
-        </RouterLink>
+      <div className="container relative mx-auto flex max-w-7xl flex-col items-center justify-between p-4 lg:flex-row lg:justify-between xl:px-0">
+        <div className={'flex w-full items-center justify-between lg:flex-1'}>
+          <RouterLink to={'/'} hover={false}>
+            <span className={'ml-2 text-2xl text-primary'}>Snack Game</span>
+          </RouterLink>
 
-        <nav className={'flex flex-1 justify-center'}>{nav}</nav>
+          <Hamburger
+            className={'h-6 w-6 text-primary lg:hidden'}
+            onClick={handleOpenToggle}
+          />
+        </div>
 
-        <div className="flex flex-1 justify-end">
+        <div className="hidden flex-1 list-none items-center justify-center gap-6 pt-6 lg:flex lg:pt-0">
+          {children}
+        </div>
+
+        <div className="mr-3 hidden flex-1 items-center justify-end space-x-4 lg:flex">
           {userInfo.accessToken ? (
             <div
               className={
@@ -57,9 +74,53 @@ const Header = ({ nav, className }: HeaderProps) => {
             <Button onClick={handleLogin}>Login</Button>
           )}
         </div>
+
+        {isToggleOpen && (
+          <motion.div
+            className={'w-full'}
+            initial={{ opacity: 0, scaleY: 0 }}
+            animate={{ opacity: 1, scaleY: 1 }}
+          >
+            <Spacing size={2} />
+            <div className={'flex flex-col items-start gap-6 px-4 lg:hidden'}>
+              {children}
+
+              {userInfo.accessToken ? (
+                <div
+                  className={
+                    'cursor-pointer font-medium text-gray-400 hover:text-primary hover:underline'
+                  }
+                  onClick={handleLogout}
+                >
+                  {userInfo.member.name} 님
+                </div>
+              ) : (
+                <Button onClick={handleLogin} className={'w-full'}>
+                  Login
+                </Button>
+              )}
+
+              {userInfo.accessToken && (
+                <Button onClick={handleLogout} className={'w-full'}>
+                  로그아웃
+                </Button>
+              )}
+            </div>
+          </motion.div>
+        )}
       </div>
     </header>
   );
 };
+
+interface ListItemProps {
+  children: ReactNode;
+}
+
+const ListItem = ({ children }: ListItemProps) => {
+  return <div>{children}</div>;
+};
+
+Header.ListItem = ListItem;
 
 export default Header;

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -83,9 +83,7 @@ const Header = ({ children, className }: HeaderProps) => {
           >
             <Spacing size={2} />
             <div className={'flex flex-col items-start gap-6 px-4 lg:hidden'}>
-              {children}
-
-              {userInfo.accessToken ? (
+              {userInfo.accessToken && (
                 <div
                   className={
                     'cursor-pointer font-medium text-gray-400 hover:text-primary hover:underline'
@@ -94,15 +92,17 @@ const Header = ({ children, className }: HeaderProps) => {
                 >
                   {userInfo.member.name} 님
                 </div>
+              )}
+              
+              {children}
+
+              {userInfo.accessToken ? (
+                <Button onClick={handleLogout} className={'w-full'}>
+                  로그아웃
+                </Button>
               ) : (
                 <Button onClick={handleLogin} className={'w-full'}>
                   Login
-                </Button>
-              )}
-
-              {userInfo.accessToken && (
-                <Button onClick={handleLogout} className={'w-full'}>
-                  로그아웃
                 </Button>
               )}
             </div>

--- a/src/components/Loading/Loading.stories.tsx
+++ b/src/components/Loading/Loading.stories.tsx
@@ -1,0 +1,19 @@
+import Loading from '@components/Loading/Loading';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/Loading',
+  component: Loading,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof Loading>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/Spacing/Spacing.tsx
+++ b/src/components/Spacing/Spacing.tsx
@@ -5,11 +5,13 @@ type Direction = 'horizontal' | 'vertical';
 interface SpacingProps {
   direction?: Direction;
   size: number;
+  className?: string;
 }
 
 export default memo(function Spacing({
   size,
   direction = 'vertical',
+  className,
   ...props
 }: SpacingProps) {
   return (
@@ -17,6 +19,7 @@ export default memo(function Spacing({
       style={{
         [direction === 'vertical' ? 'height' : 'width']: size + 'rem',
       }}
+      className={className && className}
       {...props}
     />
   );

--- a/src/pages/games/AppleGame/components/AppleGameHeader.tsx
+++ b/src/pages/games/AppleGame/components/AppleGameHeader.tsx
@@ -4,31 +4,24 @@ import GameIcon from '@assets/icon/game.svg?react';
 import RankingIcon from '@assets/icon/ranking.svg?react';
 import Header from '@components/Header/Header';
 import RouterLink from '@components/RouterLink/RouterLink';
-import Spacing from '@components/Spacing/Spacing';
 
 import PATH from '@constants/path.constant';
 
 const AppleGameHeader = () => {
-  return <Header nav={<HeaderNav />} />;
-};
-
-const HeaderNav = () => {
   const location = useLocation().pathname;
 
-  console.log(PATH.APPLE_GAME);
   return (
-    <div className={'flex'}>
-      <RouterLink
-        to={PATH.APPLE_GAME}
-        className={'items-center'}
-        isActivated={location == PATH.APPLE_GAME}
-      >
-        <GameIcon className={'mr-4 h-6 w-6'} />
-        <span>게임</span>
-      </RouterLink>
-
-      <Spacing size={3} direction={'horizontal'} />
-
+    <Header>
+      <Header.ListItem>
+        <RouterLink
+          to={PATH.APPLE_GAME}
+          className={'items-center'}
+          isActivated={location == PATH.APPLE_GAME}
+        >
+          <GameIcon className={'mr-4 h-6 w-6'} />
+          <span>게임</span>
+        </RouterLink>
+      </Header.ListItem>
       <RouterLink
         to={PATH.APPLE_GAME_RANKING}
         className={'items-center'}
@@ -37,7 +30,7 @@ const HeaderNav = () => {
         <RankingIcon className={'mr-4 h-6 w-6'} />
         <span>랭킹</span>
       </RouterLink>
-    </div>
+    </Header>
   );
 };
 


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 신규 피처
- #114 

## 📋 변경 및 추가 사항
헤더를 반응형으로 수정했습니다.
## PC 헤더
<img width="1374" alt="스크린샷 2024-01-23 22 40 17" src="https://github.com/snack-game/front/assets/16986867/4d85fd18-35a1-42ae-b7eb-7eae110da0d7" />

## 모바일 헤더
<img src="https://github.com/snack-game/front/assets/16986867/5d1828ef-98cd-4427-9b3f-41ff2e2a62f9" width=300 />

컴포넌트 컴파운딩패턴으로 아래와 같이 페이지에 따라 Header에 Nav 요소를 추가할 수 있습니다.
```tsx
<Header>
      <Header.ListItem>
        <RouterLink
          to={PATH.APPLE_GAME}
          className={'items-center'}
          isActivated={location == PATH.APPLE_GAME}
        >
          <GameIcon className={'mr-4 h-6 w-6'} />
          <span>게임</span>
        </RouterLink>
      </Header.ListItem>
      <RouterLink
        to={PATH.APPLE_GAME_RANKING}
        className={'items-center'}
        isActivated={location == PATH.APPLE_GAME_RANKING}
      >
        <RankingIcon className={'mr-4 h-6 w-6'} />
        <span>랭킹</span>
      </RouterLink>
    </Header>
```

## 💬 To. 리뷰어

이것저것 하다보니 헤더 컴포넌트가 복잡해졌네요..ㅎ
아직은 헤더가 텅텅 비어보이기도 하고 그러네요.
추후에 레벨, 개인 프로필 등 고도화 작업이 이루어지면 아래 사이트처럼 바꾸는것도 좋은것 같은데 어떻게 생각하시나요?
https://solved.ac/

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
