### PR TITLE
refactor: 랜딩 페이지 UI 수정

### DIFF
--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -62,14 +62,14 @@ const Carousel = ({ items, selected, setSelected }: CarouselProps) => {
 const CarouselItem = ({ title, image, isSelected, onClick }: CarouselItem) => {
   return (
     <div
-      className={`h-[150px] w-[200px] cursor-pointer rounded-md bg-white p-4 shadow-lg ${
+      className={`h-[150px] w-[200px] cursor-pointer rounded-md bg-white p-2 shadow-lg ${
         isSelected
           ? 'scale-100 border-2 border-primary duration-300'
           : 'scale-75 border-2 border-primary-dark duration-300'
       }`}
       onClick={onClick}
     >
-      <img src={image} alt={title} className={'h-full w-full object-cover'} />
+      <img src={image} alt={title} className={'h-full w-full object-contain'} />
     </div>
   );
 };

--- a/src/pages/main/components/HeroSection.tsx
+++ b/src/pages/main/components/HeroSection.tsx
@@ -9,8 +9,8 @@ const HeroSection = () => {
   const [selected, setSelected] = useState<number>(0);
 
   return (
-    <section className={'flex h-screen flex-col bg-primary py-12'}>
-      <div className={'flex h-full bg-white'}>
+    <section className={'flex min-h-screen flex-col bg-primary py-12'}>
+      <div className={'flex h-full grow bg-white'}>
         <Hero selected={selected} />
       </div>
       <div


### PR DESCRIPTION
## 💻 개요
- UI 리팩토링
- #115 

## 📋 변경 및 추가 사항
이미지가 일부 잘리거나, 컴포넌트 간 영역 침범으로 컨텐츠가 겹치는 현상을 고쳤습니다~!

## 비교
(왼쪽: 고친 후 / 오른쪽: 현재 배포판)

1. 캐러셀 내 사과 이미지 약간! 잘리던 현상
![image](https://github.com/snack-game/front/assets/87255462/44476067-fc81-4f76-89b5-cf9705b8fa21)

2. 화면 확대 시 HeroSection이 Spacing을 침범하던 현상
![image](https://github.com/snack-game/front/assets/87255462/4d2ccee1-19eb-48be-9c8c-8c38d4e5757a)

