### PR TITLE
refactor: 가로 모드일 때만 min-h-screen 적용

### DIFF
--- a/src/pages/main/components/HeroSection.tsx
+++ b/src/pages/main/components/HeroSection.tsx
@@ -9,7 +9,9 @@ const HeroSection = () => {
   const [selected, setSelected] = useState<number>(0);
 
   return (
-    <section className={'flex min-h-screen flex-col bg-primary py-12'}>
+    <section
+      className={'flex flex-col bg-primary py-12 landscape:min-h-screen '}
+    >
       <div className={'flex h-full grow bg-white'}>
         <Hero selected={selected} />
       </div>


### PR DESCRIPTION
## 💻 개요
- 리팩토링
- #123 

## 📋 변경 및 추가 사항
- 가로 길이가 세로보다 더 긴 landscape 모드일 때만 `min-h-screen`을 적용합니다.

|이전|이후|
|---|---|
|![image](https://github.com/snack-game/front/assets/87255462/fcc39243-acc8-43f4-b154-08650dcbb752)|![image](https://github.com/snack-game/front/assets/87255462/ab2274d4-230c-4e70-b54d-2beedf8b2277)|
