### PR TITLE
refactor: 토큰 관리 수정, 유저 만료기간 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,18 @@
-import React, { lazy, Suspense } from 'react';
+import React, { lazy, Suspense, useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 import { inject } from '@vercel/analytics';
+import { useResetRecoilState } from 'recoil';
 
 import ErrorBoundary from '@components/base/ErrorBoundary';
 import Loading from '@components/Loading/Loading';
 import Modal from '@components/Modal/Modal';
 import Toast from '@components/Toast/Toast';
+import { resetUserState } from '@utils/atoms/member.atom';
 
+import { LOCAL_STORAGE_KEY } from '@constants/localStorage.constant';
 import PATH from '@constants/path.constant';
+import useLocalStorage from '@hooks/useLocalStorage';
 
 inject();
 
@@ -27,6 +31,31 @@ const OAuthPage = lazy(() => import('@pages/oauth/OAuthPage'));
 const ErrorPage = lazy(() => import('@pages/error/ErrorPage'));
 
 const App = () => {
+  const resetUser = useResetRecoilState(resetUserState);
+  const { storageValue, deleteStorageValue } = useLocalStorage<string>({
+    key: LOCAL_STORAGE_KEY.USER_EXPIRE_TIME,
+  });
+  const { deleteStorageValue: deleteUserPersistState } =
+    useLocalStorage<string>({
+      key: 'userPersistState',
+    });
+
+  useEffect(() => {
+    const checkUserExpired = () => {
+      const currentTime = Date.now();
+      const oneMonthInMilliseconds = 30 * 24 * 60 * 60 * 1000;
+      const expireTime = parseInt(storageValue, 10);
+
+      if (expireTime && currentTime - expireTime > oneMonthInMilliseconds) {
+        resetUser();
+        deleteUserPersistState();
+        deleteStorageValue();
+      }
+    };
+
+    checkUserExpired();
+  }, []);
+
   return (
     <>
       <ErrorBoundary fallback={ErrorPage}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,8 @@ const App = () => {
 
   useEffect(() => {
     const checkUserExpired = () => {
+      if (!storageValue) return;
+
       const currentTime = Date.now();
       const oneMonthInMilliseconds = 30 * 24 * 60 * 60 * 1000;
       const expireTime = parseInt(storageValue, 10);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -14,12 +14,20 @@ api.interceptors.response.use(
   async (error) => {
     if (error.response) {
       const { action } = error.response.data;
+      const originalRequest = error.config;
+      if (!originalRequest._retry) {
+        // _retry 플래그를 사용하여 무한 재시도 방지
+        originalRequest._retry = true;
 
-      switch (action) {
-        case 'REISSUE': {
-          await authApi.tokenReIssue();
-          api.request(error.config);
-          break;
+        switch (action) {
+          case 'REISSUE': {
+            await authApi.tokenReIssue();
+            return api.request(originalRequest);
+          }
+          case null: {
+            await authApi.logOut();
+            break;
+          }
         }
       }
     }

--- a/src/components/Auth/OAuth.tsx
+++ b/src/components/Auth/OAuth.tsx
@@ -8,7 +8,9 @@ import KaKaoSingIn from '@assets/images/kakao.png';
 import { userState } from '@utils/atoms/member.atom';
 import { MemberType } from '@utils/types/member.type';
 
+import { LOCAL_STORAGE_KEY } from '@constants/localStorage.constant';
 import PATH from '@constants/path.constant';
+import useLocalStorage from '@hooks/useLocalStorage';
 import useToast from '@hooks/useToast';
 
 interface DialogProps {
@@ -23,6 +25,9 @@ interface OAuthContainerProps {
 const OAuth = ({ oAuthOnSuccess }: OAuthContainerProps) => {
   const { t } = useTranslation();
   const [popup, setPopup] = useState<boolean>(false);
+  const { setStorageValue } = useLocalStorage({
+    key: LOCAL_STORAGE_KEY.USER_EXPIRE_TIME,
+  });
 
   const setUserState = useSetRecoilState(userState);
   const openToast = useToast();
@@ -51,6 +56,7 @@ const OAuth = ({ oAuthOnSuccess }: OAuthContainerProps) => {
       setUserState(() => ({
         member,
       }));
+      setStorageValue(Date.now());
     }
 
     if (event.data.type === 'oAuthError') {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -12,7 +12,9 @@ import RouterLink from '@components/RouterLink/RouterLink';
 import Spacing from '@components/Spacing/Spacing';
 import { resetUserState, userState } from '@utils/atoms/member.atom';
 
+import { LOCAL_STORAGE_KEY } from '@constants/localStorage.constant';
 import PATH from '@constants/path.constant';
+import useLocalStorage from '@hooks/useLocalStorage';
 import useModal from '@hooks/useModal';
 import useToast from '@hooks/useToast';
 
@@ -28,6 +30,9 @@ const Header = ({ children, className }: HeaderProps) => {
   const userInfo = useRecoilValue(userState);
   const navigate = useNavigate();
   const [isToggleOpen, setIsToggleOpen] = useState(false);
+  const { deleteStorageValue } = useLocalStorage({
+    key: LOCAL_STORAGE_KEY.USER_EXPIRE_TIME,
+  });
 
   const handleLogin = () => {
     openModal({ children: <Auth /> });
@@ -37,6 +42,7 @@ const Header = ({ children, className }: HeaderProps) => {
     resetUser();
     await authApi.logOut();
     openToast('로그아웃 성공!', 'success');
+    deleteStorageValue();
     navigate(PATH.MAIN, { replace: true });
   };
 

--- a/src/constants/localStorage.constant.ts
+++ b/src/constants/localStorage.constant.ts
@@ -1,0 +1,3 @@
+export const LOCAL_STORAGE_KEY = {
+  USER_EXPIRE_TIME: 'userExpireTime',
+};

--- a/src/hooks/queries/auth.query.ts
+++ b/src/hooks/queries/auth.query.ts
@@ -9,6 +9,8 @@ import { userState } from '@utils/atoms/member.atom';
 import { MemberType } from '@utils/types/member.type';
 
 import { ServerError } from '@constants/api.constant';
+import { LOCAL_STORAGE_KEY } from '@constants/localStorage.constant';
+import useLocalStorage from '@hooks/useLocalStorage';
 import useModal from '@hooks/useModal';
 import useToast from '@hooks/useToast';
 
@@ -21,11 +23,15 @@ const useMemberOnSuccess = () => {
   const openToast = useToast();
   const setUserState = useSetRecoilState(userState);
   const { closeModal } = useModal();
+  const { setStorageValue } = useLocalStorage({
+    key: LOCAL_STORAGE_KEY.USER_EXPIRE_TIME,
+  });
 
   return ({ member }: MemberType) => {
     setUserState(() => ({
       member,
     }));
+    setStorageValue(Date.now());
     openToast(t('login_success'), 'success');
     closeModal();
   };


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 신규 피처
- #131 

## 📋 변경 및 추가 사항
로그인 수행시 현재 시간을 기준으로 시간을 localstorage에 기록합니다.
해당 유저 로그인 시간은 토큰 재발급 시에 refreshToken과 함께 갱신이 됩니다.
App 에서는 최초 접속 시 유저 만료기한을 체크하고 현재 시간과 유저의 로그인 시간 정보가 1달 이상 차이가 난다면 토큰들은 모두 만료된것으로 판단, 유저 정보를 지우고 localstorage의 값도 마찬가지로 삭제합니다.

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
