### PR TITLE
Fix: 랜딩 페이지, 헤더 UI 버그 수정

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -85,7 +85,7 @@ const Header = ({ children, className }: HeaderProps) => {
 
         {isToggleOpen && (
           <motion.div
-            className={'w-full'}
+            className={'w-full lg:w-0'}
             initial={{ opacity: 0, scaleY: 0 }}
             animate={{ opacity: 1, scaleY: 1 }}
           >

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -81,7 +81,7 @@ const Hero = ({ selected }: HeroProps) => {
 
   return (
     <motion.div
-      className="mx-auto mt-16 flex w-full max-w-7xl flex-col-reverse items-center justify-between p-2 lg:mt-0 lg:flex-row"
+      className="mx-auto mt-16 flex w-full max-w-7xl flex-col-reverse items-center justify-around p-2 lg:mt-0 lg:flex-row"
       key={selected}
     >
       <motion.div


### PR DESCRIPTION
## 💻 개요

- 이슈대응

- #132 

## 📋 변경 및 추가 사항

- 항상 랜딩 페이지 내 `HeroSection`의 양쪽 여백을 보장하기 위해 space-between ➡ space-around로 수정했습니다
- 특정 상황에서 `Header`의 여백이 과하게 생기는 문제를 해결했습니다

![test](https://github.com/snack-game/front/assets/87255462/944dbf37-19b6-4a81-a6eb-153003021914)


