### PR TITLE
refactor: react query 버전업

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,8 @@
     "plugin:react/recommended",
     "plugin:import/typescript",
     "plugin:import/recommended",
-    "plugin:storybook/recommended"
+    "plugin:storybook/recommended",
+    "plugin:@tanstack/eslint-plugin-query/recommended"
   ],
   "overrides": [],
   "parser": "@typescript-eslint/parser",
@@ -18,11 +19,7 @@
     "ecmaVersion": "latest",
     "sourceType": "module"
   },
-  "plugins": [
-    "react",
-    "@typescript-eslint",
-    "import"
-  ],
+  "plugins": ["react", "@typescript-eslint", "import"],
   "settings": {
     "react": {
       "version": "detect"
@@ -33,19 +30,14 @@
       }
     },
     "import/parsers": {
-      "@typescript-eslint/parser": [
-        ".ts",
-        ".tsx"
-      ]
+      "@typescript-eslint/parser": [".ts", ".tsx"]
     }
   },
   "rules": {
     "react/no-unknown-property": [
       "error",
       {
-        "ignore": [
-          "css"
-        ]
+        "ignore": ["css"]
       }
     ],
     "import/order": [
@@ -55,11 +47,7 @@
           "builtin",
           "external",
           "internal",
-          [
-            "parent",
-            "sibling",
-            "index"
-          ],
+          ["parent", "sibling", "index"],
           "type",
           "unknown"
         ],
@@ -80,10 +68,7 @@
             "position": "before"
           }
         ],
-        "pathGroupsExcludedImportTypes": [
-          "react",
-          "unknown"
-        ],
+        "pathGroupsExcludedImportTypes": ["react", "unknown"],
         "newlines-between": "always",
         "alphabetize": {
           "order": "asc",
@@ -94,11 +79,7 @@
     "import/no-unresolved": [
       2,
       {
-        "ignore": [
-          ".png$",
-          ".webp$",
-          ".jpg$"
-        ]
+        "ignore": [".png$", ".webp$", ".jpg$"]
       }
     ],
     "@typescript-eslint/no-non-null-assertion": "off",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@storybook/addon-styling-webpack": "^0.0.5",
     "@storybook/addon-themes": "^7.6.6",
+    "@tanstack/react-query": "^5.24.7",
+    "@tanstack/react-query-devtools": "^5.24.7",
     "@testing-library/dom": "^9.3.1",
     "@types/styled-components": "^5.1.26",
     "@vercel/analytics": "^1.1.1",
@@ -37,7 +39,6 @@
     "react-hooks-testing-library": "^0.6.0",
     "react-hot-toast": "^2.4.1",
     "react-i18next": "^13.5.0",
-    "react-query": "^3.39.3",
     "react-router-dom": "^6.11.2",
     "recoil": "^0.7.7",
     "recoil-persist": "^5.1.0"
@@ -53,7 +54,7 @@
     "@storybook/react-vite": "^7.6.6",
     "@storybook/test": "^7.6.6",
     "@svgr/core": "^8.1.0",
-    "@tanstack/eslint-plugin-query": "^4.29.9",
+    "@tanstack/eslint-plugin-query": "^4.38.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@types/jest": "^29.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ dependencies:
   '@storybook/addon-themes':
     specifier: ^7.6.6
     version: 7.6.17
+  '@tanstack/react-query':
+    specifier: ^5.24.7
+    version: 5.24.8(react@18.2.0)
+  '@tanstack/react-query-devtools':
+    specifier: ^5.24.7
+    version: 5.24.8(@tanstack/react-query@5.24.8)(react@18.2.0)
   '@testing-library/dom':
     specifier: ^9.3.1
     version: 9.3.4
@@ -77,9 +83,6 @@ dependencies:
   react-i18next:
     specifier: ^13.5.0
     version: 13.5.0(i18next@23.10.0)(react-dom@18.2.0)(react@18.2.0)
-  react-query:
-    specifier: ^3.39.3
-    version: 3.39.3(react-dom@18.2.0)(react@18.2.0)
   react-router-dom:
     specifier: ^6.11.2
     version: 6.22.2(react-dom@18.2.0)(react@18.2.0)
@@ -122,7 +125,7 @@ devDependencies:
     specifier: ^8.1.0
     version: 8.1.0(typescript@5.3.3)
   '@tanstack/eslint-plugin-query':
-    specifier: ^4.29.9
+    specifier: ^4.38.0
     version: 4.38.0(eslint@8.57.0)
   '@testing-library/jest-dom':
     specifier: ^5.16.5
@@ -3756,6 +3759,34 @@ packages:
       eslint: 8.57.0
     dev: true
 
+  /@tanstack/query-core@5.24.8:
+    resolution: {integrity: sha512-yH7KnfXMf10p1U5GffTQzFi2Miiw6WJZImGYGdV7eqa5ZbKO8qVx9lOA9SfhIaJXomrMp1Yz5w/CBhVM3yWeTA==}
+    dev: false
+
+  /@tanstack/query-devtools@5.24.0:
+    resolution: {integrity: sha512-pThim455t69zrZaQKa7IRkEIK8UBTS+gHVAdNfhO72Xh4rWpMc63ovRje5/n6iw63+d6QiJzVadsJVdPoodSeQ==}
+    dev: false
+
+  /@tanstack/react-query-devtools@5.24.8(@tanstack/react-query@5.24.8)(react@18.2.0):
+    resolution: {integrity: sha512-OfNbyOF07/3PXH1fdLs/2BxjpXv2hFI777iym2L0lVGQbyVSJAUbGXYaCvgjZIdan/vfiXf3sjCVkO8mD9hf0Q==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.24.8
+      react: ^18.0.0
+    dependencies:
+      '@tanstack/query-devtools': 5.24.0
+      '@tanstack/react-query': 5.24.8(react@18.2.0)
+      react: 18.2.0
+    dev: false
+
+  /@tanstack/react-query@5.24.8(react@18.2.0):
+    resolution: {integrity: sha512-jB3JS9SzDmBySk9VVOTPt/0ixWEb3K3dy9IExlVl/1NouY3N7HzAqG/1d4m6E9eFfKJoLvA/hBksaLu0lw627A==}
+    peerDependencies:
+      react: ^18.0.0
+    dependencies:
+      '@tanstack/query-core': 5.24.8
+      react: 18.2.0
+    dev: false
+
   /@testing-library/dom@9.3.4:
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
     engines: {node: '>=14'}
@@ -5080,6 +5111,7 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+    dev: true
 
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -5094,6 +5126,7 @@ packages:
   /big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
+    dev: true
 
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -5138,6 +5171,7 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+    dev: true
 
   /brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
@@ -5150,19 +5184,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-
-  /broadcast-channel@3.7.0:
-    resolution: {integrity: sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==}
-    dependencies:
-      '@babel/runtime': 7.24.0
-      detect-node: 2.1.0
-      js-sha3: 0.8.0
-      microseconds: 0.2.0
-      nano-time: 1.0.0
-      oblivious-set: 1.0.0
-      rimraf: 3.0.2
-      unload: 2.2.0
-    dev: false
 
   /browser-assert@1.2.1:
     resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
@@ -5482,6 +5503,7 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    dev: true
 
   /concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -5805,10 +5827,6 @@ packages:
   /detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
     dev: true
-
-  /detect-node@2.1.0:
-    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
-    dev: false
 
   /detect-package-manager@2.0.1:
     resolution: {integrity: sha512-j/lJHyoLlWi6G1LDdLgvUtz60Zo5GEj+sVYtTVXnYLDPuzgC3llMxonXym9zIwhhUII8vjdw0LXxavpLqTbl1A==}
@@ -6957,6 +6975,7 @@ packages:
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
 
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -7114,6 +7133,7 @@ packages:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+    dev: true
 
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -7412,6 +7432,7 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
+    dev: true
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -8279,10 +8300,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /js-sha3@0.8.0:
-    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
-    dev: false
-
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -8635,13 +8652,6 @@ packages:
       react: 18.2.0
     dev: true
 
-  /match-sorter@6.3.4:
-    resolution: {integrity: sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==}
-    dependencies:
-      '@babel/runtime': 7.24.0
-      remove-accents: 0.5.0
-    dev: false
-
   /mdast-util-definitions@4.0.0:
     resolution: {integrity: sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==}
     dependencies:
@@ -8692,10 +8702,6 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /microseconds@0.2.0:
-    resolution: {integrity: sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==}
-    dev: false
-
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
@@ -8736,6 +8742,7 @@ packages:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
+    dev: true
 
   /minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
@@ -8855,12 +8862,6 @@ packages:
       object-assign: 4.1.1
       thenify-all: 1.6.0
     dev: true
-
-  /nano-time@1.0.0:
-    resolution: {integrity: sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==}
-    dependencies:
-      big-integer: 1.6.52
-    dev: false
 
   /nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
@@ -9044,10 +9045,6 @@ packages:
       es-abstract: 1.22.5
     dev: true
 
-  /oblivious-set@1.0.0:
-    resolution: {integrity: sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==}
-    dev: false
-
   /ohash@1.1.3:
     resolution: {integrity: sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw==}
     dev: true
@@ -9068,6 +9065,7 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
+    dev: true
 
   /onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -9218,6 +9216,7 @@ packages:
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -9810,25 +9809,6 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
-  /react-query@3.39.3(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: '*'
-      react-native: '*'
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.24.0
-      broadcast-channel: 3.7.0
-      match-sorter: 6.3.4
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-    dev: false
-
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
@@ -10114,10 +10094,6 @@ packages:
       unist-util-visit: 2.0.3
     dev: true
 
-  /remove-accents@0.5.0:
-    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
-    dev: false
-
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -10206,6 +10182,7 @@ packages:
     hasBin: true
     dependencies:
       glob: 7.2.3
+    dev: true
 
   /rollup@2.79.1:
     resolution: {integrity: sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==}
@@ -11249,13 +11226,6 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unload@2.2.0:
-    resolution: {integrity: sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==}
-    dependencies:
-      '@babel/runtime': 7.24.0
-      detect-node: 2.1.0
-    dev: false
-
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -11671,6 +11641,7 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+    dev: true
 
   /write-file-atomic@2.4.3:
     resolution: {integrity: sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useEffect } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 import { inject } from '@vercel/analytics';

--- a/src/components/base/QueryBoundary.tsx
+++ b/src/components/base/QueryBoundary.tsx
@@ -1,5 +1,6 @@
 import { ComponentType, ReactNode, Suspense } from 'react';
-import { useQueryErrorResetBoundary } from 'react-query';
+
+import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 
 import Loading from '@components/Loading/Loading';
 

--- a/src/hooks/queries/appleGame.query.ts
+++ b/src/hooks/queries/appleGame.query.ts
@@ -1,12 +1,10 @@
-import { useMutation } from 'react-query';
-
+import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useRecoilValue } from 'recoil';
 
 import appleGameApi from '@api/apple-game.api';
 import { scoredAppleRectType } from '@pages/games/AppleGame/game/game.type';
 import { userState } from '@utils/atoms/member.atom';
-import { MemberType } from '@utils/types/member.type';
 
 import { ServerError } from '@constants/api.constant';
 import { useGuest } from '@hooks/queries/auth.query';
@@ -35,7 +33,7 @@ export const useGoldModeStart = () => {
   const gameStartMutation = useMutation({
     mutationFn: appleGameApi.gameStart,
     onError: useAppleGameError(),
-    useErrorBoundary: appleGameErrorBoundary,
+    throwOnError: appleGameErrorBoundary,
   });
 
   const gameStart = async () => {
@@ -54,7 +52,7 @@ export const useAppleGameSessionEnd = () => {
   const gameEnd = useMutation({
     mutationFn: appleGameApi.gameEnd,
     onError: useAppleGameError(),
-    useErrorBoundary: appleGameErrorBoundary,
+    throwOnError: appleGameErrorBoundary,
   });
 
   return { gameEnd };
@@ -64,7 +62,7 @@ export const useGoldModeCheck = () => {
   const checkGameMove = useMutation({
     mutationFn: appleGameApi.checkGameMove,
     onError: useAppleGameError(),
-    useErrorBoundary: appleGameErrorBoundary,
+    throwOnError: appleGameErrorBoundary,
   });
 
   const checkMoves = async (
@@ -88,6 +86,6 @@ export const useAppleGameRefresh = () => {
   return useMutation({
     mutationFn: appleGameApi.gameRefresh,
     onError: useAppleGameError(),
-    useErrorBoundary: appleGameErrorBoundary,
+    throwOnError: appleGameErrorBoundary,
   });
 };

--- a/src/hooks/queries/auth.query.ts
+++ b/src/hooks/queries/auth.query.ts
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { useMutation } from 'react-query';
 
+import { useMutation } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useSetRecoilState } from 'recoil';
 
@@ -60,7 +60,7 @@ export const useMemberAuth = ({ apiMethod }: useMemberAuthProps) => {
     mutationFn: apiMethod,
     onSuccess,
     onError: useOnError(),
-    useErrorBoundary: memberErrorBoundary,
+    throwOnError: memberErrorBoundary,
   });
 };
 
@@ -69,7 +69,7 @@ export const useGuest = () => {
     mutationFn: authApi.guest,
     onSuccess: useMemberOnSuccess(),
     onError: useOnError(),
-    useErrorBoundary: memberErrorBoundary,
+    throwOnError: memberErrorBoundary,
   });
 };
 

--- a/src/hooks/queries/groups.query.ts
+++ b/src/hooks/queries/groups.query.ts
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { useMutation, useQuery } from 'react-query';
 
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import groupsApi from '@api/groups.api';
@@ -17,14 +17,11 @@ export const useGetGroupsNames = ({
   startWidth,
   enabled,
 }: useGetGroupsNamesProps) => {
-  const { isLoading, data } = useQuery<string[], AxiosError>(
-    [QUERY_KEY.GROUPS_NAMES, startWidth],
-    () => groupsApi.getGroupsNames(startWidth),
-    {
-      useErrorBoundary: true,
-      enabled,
-    },
-  );
+  const { isLoading, data } = useQuery<string[], AxiosError>({
+    queryKey: [QUERY_KEY.GROUPS_NAMES, startWidth],
+    queryFn: () => groupsApi.getGroupsNames(startWidth),
+    enabled,
+  });
 
   return { isLoading, data };
 };
@@ -43,7 +40,7 @@ export const useChangeGroupName = () => {
 
       openToast(error.response.data.messages, 'error');
     },
-    useErrorBoundary: (error: AxiosError<ServerError>) => {
+    throwOnError: (error: AxiosError<ServerError>) => {
       if (!error.response) throw error;
 
       return error.response?.status >= 500;

--- a/src/hooks/queries/members.query.ts
+++ b/src/hooks/queries/members.query.ts
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { useMutation, useQuery } from 'react-query';
 
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import membersApi from '@api/members.api';
@@ -18,7 +18,7 @@ export const useChangeUserName = () => {
       openToast(t('member_change_name'), 'success');
     },
     onError: useOnError(),
-    useErrorBoundary: (error: AxiosError<ServerError>) => {
+    throwOnError: (error: AxiosError<ServerError>) => {
       if (!error.response) throw error;
 
       return error.response?.status >= 500;
@@ -43,14 +43,10 @@ export const useIntegrateMember = () => {
 };
 
 export const useGetMemberProfile = () => {
-  const { data } = useQuery(
-    QUERY_KEY.USER_PROFILE,
-    membersApi.getMemberProfile,
-    {
-      suspense: true,
-      useErrorBoundary: true,
-    },
-  );
+  const { data } = useSuspenseQuery({
+    queryKey: [QUERY_KEY.USER_PROFILE],
+    queryFn: membersApi.getMemberProfile,
+  });
 
   return data;
 };

--- a/src/hooks/queries/ranking.query.ts
+++ b/src/hooks/queries/ranking.query.ts
@@ -1,5 +1,4 @@
-import { useQuery } from 'react-query';
-
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import rankingApi from '@api/ranking.api';
@@ -8,31 +7,24 @@ import { RankingType } from '@utils/types/common.type';
 import { QUERY_KEY, ServerError } from '@constants/api.constant';
 
 export const useGetTotalRanking = () => {
-  const { data } = useQuery<RankingType[], AxiosError>(
-    QUERY_KEY.TOTAL_RANKING,
-    rankingApi.totalRanking,
-    {
-      suspense: true,
-      useErrorBoundary: true,
-    },
-  );
+  const { data } = useSuspenseQuery<RankingType[], AxiosError>({
+    queryKey: [QUERY_KEY.TOTAL_RANKING],
+    queryFn: rankingApi.totalRanking,
+  });
 
   return data;
 };
 
 export const useGetUserRanking = () => {
-  const { data } = useQuery<RankingType, AxiosError<ServerError>>(
-    QUERY_KEY.USER_RANKING,
-    rankingApi.userRanking,
-    {
-      suspense: true,
-      useErrorBoundary: (error: AxiosError<ServerError>) => {
-        if (!error.response) throw error;
+  const { data } = useQuery<RankingType, AxiosError<ServerError>>({
+    queryKey: [QUERY_KEY.USER_RANKING],
+    queryFn: rankingApi.userRanking,
+    throwOnError: (error: AxiosError<ServerError>) => {
+      if (!error.response) throw error;
 
-        return error.response?.status >= 500;
-      },
+      return error.response?.status >= 500;
     },
-  );
+  });
 
   return data;
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,9 @@ import React, { useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import ReactGA from 'react-ga4';
 import { HelmetProvider } from 'react-helmet-async';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { BrowserRouter } from 'react-router-dom';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RecoilRoot } from 'recoil';
 
 import App from './App';
@@ -14,10 +14,11 @@ const queryClient = new QueryClient({
     queries: {
       retry: false,
       refetchOnWindowFocus: false,
+      throwOnError: true,
     },
     mutations: {
       retry: false,
-      useErrorBoundary: true,
+      throwOnError: true,
     },
   },
 });
@@ -33,17 +34,15 @@ const Root = () => {
   });
 
   return (
-    <React.StrictMode>
-      <HelmetProvider>
-        <BrowserRouter>
-          <QueryClientProvider client={queryClient}>
-            <RecoilRoot>
-              <App />
-            </RecoilRoot>
-          </QueryClientProvider>
-        </BrowserRouter>
-      </HelmetProvider>
-    </React.StrictMode>
+    <HelmetProvider>
+      <BrowserRouter>
+        <QueryClientProvider client={queryClient}>
+          <RecoilRoot>
+            <App />
+          </RecoilRoot>
+        </QueryClientProvider>
+      </BrowserRouter>
+    </HelmetProvider>
   );
 };
 

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -1,5 +1,4 @@
-import { useQueryClient } from 'react-query';
-
+import { useQueryClient } from '@tanstack/react-query';
 import { useSetRecoilState } from 'recoil';
 
 import CameraIcon from '@assets/icon/camera.svg?react';
@@ -85,7 +84,7 @@ const ProfileSection = ({
         group: { name: newGroup },
       },
     }));
-    queryClient.invalidateQueries(QUERY_KEY.USER_PROFILE);
+    queryClient.invalidateQueries({ queryKey: [QUERY_KEY.USER_PROFILE] });
     onClickDone();
   };
 


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 리펙토링
- #157 

## 📋 변경 및 추가 사항
react query 라이브러리의 버전을 v3 -> v5로 업데이트 했습니다.
react query v5의 주요 변경사항은 아래 공식문서에서 확인가능합니다!
[주요 변경사항 참고 공식문서](https://tanstack.com/query/v5/docs/framework/react/guides/migrating-to-v5)

## useMutation
* useErrorboundary 옵션의 이름이 변경되었습니다: throwOnError

## useQuery
* query key의 경우 옵션 필드에 queryKey로 명시해주어야 합니다.
* 기존 string으로 넣어주던 key는 배열로 변경되었습니다.
* [v4 공식문서](https://tanstack.com/query/v4/docs/framework/react/guides/migrating-to-react-query-4)
```
- useQuery('todos', fetchTodos)
+ useQuery(['todos'], fetchTodos)
```
* suspens: true나 throwOnError: true를 켜줄필요 없는 useSuspenQuery가 추가되었습니다.


## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
