### PR TITLE
fix: `StatusType`의 `maximumExp` -> `maxExp`

### DIFF
--- a/src/pages/user/components/ExpChart.tsx
+++ b/src/pages/user/components/ExpChart.tsx
@@ -9,7 +9,7 @@ import { TIER_COLOR, PRIMARY_COLOR } from '@constants/tier.constant';
 ChartJS.register(ArcElement);
 
 const ExpChart = ({ status }: { status: StatusType }) => {
-  const { level, exp, maximumExp } = status;
+  const { level, exp, maxExp } = status;
   const tier = Math.floor(level / 10);
 
   const data = {
@@ -23,7 +23,7 @@ const ExpChart = ({ status }: { status: StatusType }) => {
   };
 
   function calculateData() {
-    const currentRatio = (exp / maximumExp) * 100;
+    const currentRatio = (exp / maxExp) * 100;
     return [currentRatio, 100 - currentRatio];
   }
 

--- a/src/utils/types/member.type.ts
+++ b/src/utils/types/member.type.ts
@@ -18,7 +18,7 @@ export interface MemberType {
 export interface StatusType {
   level: number;
   exp: number;
-  maximumExp: number;
+  maxExp: number;
 }
 
 export interface MemberProfileType {


### PR DESCRIPTION
## 💻 개요

- 이슈 대응
- #159

## 📋 변경 및 추가 사항

- 경험치 관련 `StatusType`의 속성명을 서버 스키마랑 동일하게 살짝. 수정했어요

## 💬 To. 리뷰어

실행 화면이 달라진 건 없어서 사진은 첨부하지 않았습니다~!
