### PR TITLE
refactor: `MemberType` member 속성 제거, `MemberProfileType` 삭제

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -11,36 +11,37 @@ const authApi = {
     tokenReIssue: 'tokens/me',
   },
 
-  login: async ({ member }: MemberType): Promise<MemberType> => {
+  login: async (member: MemberType): Promise<MemberType> => {
     const { data } = await api.post(authApi.endPoint.login, {
       name: member.name,
     });
-    return { member: data.member };
+
+    return data.member ? { ...data.member } : data;
   },
 
   logOut: async (): Promise<void> => {
     await api.delete(authApi.endPoint.logOut);
   },
 
-  register: async ({ member }: MemberType): Promise<MemberType> => {
+  register: async (member: MemberType): Promise<MemberType> => {
     const { data } = await api.post(authApi.endPoint.register, {
       name: member.name,
       group: member.group?.name,
     });
 
-    return { member: data.member };
+    return data.member ? { ...data.member } : data;
   },
 
   guest: async (): Promise<MemberType> => {
     const { data } = await api.post(authApi.endPoint.guest);
 
-    return { member: data.member };
+    return data.member ? { ...data.member } : data;
   },
 
   social: async (): Promise<MemberType> => {
     const { data } = await api.post(authApi.endPoint.social, {});
 
-    return { member: data.member };
+    return data.member ? { ...data.member } : data;
   },
 
   tokenReIssue: async (): Promise<void> => {

--- a/src/api/members.api.ts
+++ b/src/api/members.api.ts
@@ -1,5 +1,5 @@
 import api from '@api/index';
-import { MemberProfileType, MemberType } from '@utils/types/member.type';
+import { MemberType } from '@utils/types/member.type';
 
 const membersApi = {
   endPoint: {
@@ -18,7 +18,7 @@ const membersApi = {
     return data;
   },
 
-  getMemberProfile: async (): Promise<MemberProfileType> => {
+  getMemberProfile: async (): Promise<MemberType> => {
     const { data } = await api.get(membersApi.endPoint.getMemberProfile);
     return data;
   },

--- a/src/components/Auth/OAuth.tsx
+++ b/src/components/Auth/OAuth.tsx
@@ -51,10 +51,10 @@ const OAuth = ({ oAuthOnSuccess }: OAuthContainerProps) => {
     if (event.origin !== window.location.origin) return;
 
     if (event.data.type === 'oAuthSuccess') {
-      const { member } = await oAuthOnSuccess();
+      const member = await oAuthOnSuccess();
       openToast('로그인 성공!', 'success');
       setUserState(() => ({
-        member,
+        ...member,
       }));
       setStorageValue(Date.now());
     }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -69,14 +69,14 @@ const Header = ({ children, className }: HeaderProps) => {
         </div>
 
         <div className="mr-3 hidden flex-1 items-center justify-end space-x-4 lg:flex">
-          {userInfo.member.id ? (
+          {userInfo.id ? (
             <div
               className={
                 'cursor-pointer text-sm text-primary-deep-dark hover:text-primary hover:underline'
               }
               onClick={handleLogout}
             >
-              {userInfo.member.name} 님
+              {userInfo.name} 님
             </div>
           ) : (
             <Button onClick={handleLogin}>Login</Button>
@@ -91,20 +91,20 @@ const Header = ({ children, className }: HeaderProps) => {
           >
             <Spacing size={2} />
             <div className={'flex flex-col items-start gap-6 px-4 lg:hidden'}>
-              {userInfo.member.id && (
+              {userInfo.id && (
                 <div
                   className={
                     'cursor-pointer font-medium text-gray-400 hover:text-primary hover:underline'
                   }
                   onClick={handleLogout}
                 >
-                  {userInfo.member.name} 님
+                  {userInfo.name} 님
                 </div>
               )}
 
               {children}
 
-              {userInfo.member.id ? (
+              {userInfo.id ? (
                 <Button onClick={handleLogout} className={'w-full'}>
                   로그아웃
                 </Button>

--- a/src/hooks/queries/appleGame.query.ts
+++ b/src/hooks/queries/appleGame.query.ts
@@ -37,7 +37,7 @@ export const useGoldModeStart = () => {
   });
 
   const gameStart = async () => {
-    if (!userStateValue.member.id) {
+    if (!userStateValue.id) {
       await guestMutation.mutateAsync();
       return await gameStartMutation.mutateAsync();
     } else {

--- a/src/hooks/queries/auth.query.ts
+++ b/src/hooks/queries/auth.query.ts
@@ -27,9 +27,9 @@ const useMemberOnSuccess = () => {
     key: LOCAL_STORAGE_KEY.USER_EXPIRE_TIME,
   });
 
-  return ({ member }: MemberType) => {
+  return (member: MemberType) => {
     setUserState(() => ({
-      member,
+      ...member,
     }));
     setStorageValue(Date.now());
     openToast(t('login_success'), 'success');

--- a/src/pages/games/AppleGame/components/GameResult.tsx
+++ b/src/pages/games/AppleGame/components/GameResult.tsx
@@ -34,7 +34,7 @@ const GameResult = ({ score, reStart }: GameResultProps) => {
           재시작!
         </Button>
       </div>
-      {userStateValue.member.type === 'GUEST' && (
+      {userStateValue.type === 'GUEST' && (
         <OAuth oAuthOnSuccess={onOAuthSuccess} />
       )}
     </div>

--- a/src/pages/games/AppleGame/components/RankingSection.tsx
+++ b/src/pages/games/AppleGame/components/RankingSection.tsx
@@ -19,7 +19,7 @@ const RankingSection = () => {
     <div className={'mx-auto w-full max-w-4xl'}>
       {topRanking && <TopRanking topRanking={topRanking} />}
       {otherRanking && <OtherRanking otherRanking={otherRanking} />}
-      {userInfo.member.id && <UserRanking />}
+      {userInfo.id && <UserRanking />}
     </div>
   );
 };

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -77,12 +77,10 @@ const ProfileSection = ({
       await changeGroupName.mutateAsync(newGroup);
     }
 
-    setUserState((prev) => ({
-      member: {
-        ...prev.member,
-        name: newName,
-        group: { name: newGroup },
-      },
+    setUserState((prevInfo) => ({
+      ...prevInfo,
+      name: newName,
+      group: { name: newGroup },
     }));
     queryClient.invalidateQueries({ queryKey: [QUERY_KEY.USER_PROFILE] });
     onClickDone();

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -6,7 +6,7 @@ import EditIcon from '@assets/icon/edit.svg?react';
 import DefaultImage from '@assets/images/profile_image.png';
 import Button from '@components/Button/Button';
 import { userState } from '@utils/atoms/member.atom';
-import { MemberProfileType } from '@utils/types/member.type';
+import { MemberType } from '@utils/types/member.type';
 
 import { QUERY_KEY } from '@constants/api.constant';
 import { GROUP_CHANGE_REGEXP, NAME_REGEXP } from '@constants/regexp.constant';
@@ -21,7 +21,7 @@ import useInput from '@hooks/useInput';
 import ExpChart from './ExpChart';
 
 interface ProfileSectionProps {
-  profile: MemberProfileType;
+  profile: MemberType;
   isEditing: boolean;
   onClickEdit: () => void;
   onClickDone: () => void;

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -89,7 +89,7 @@ const ProfileSection = ({
   return (
     <div className={'absolute top-32 flex flex-col items-center'}>
       <div className={'relative'}>
-        <ExpChart status={profile.status} />
+        {profile.status && <ExpChart status={profile.status} />}
         <img
           className={'absolute left-2 top-2 mb-4 w-40 rounded-full'}
           src={DefaultImage}

--- a/src/utils/atoms/member.atom.ts
+++ b/src/utils/atoms/member.atom.ts
@@ -12,10 +12,8 @@ const { persistAtom: persistAtomUser } = recoilPersist({
 export const userState = atom<MemberType>({
   key: ATOM_KEY.USER,
   default: {
-    member: {
-      name: '',
-      group: null,
-    },
+    name: '',
+    group: null,
   },
   effects_UNSTABLE: [persistAtomUser],
 });

--- a/src/utils/types/member.type.ts
+++ b/src/utils/types/member.type.ts
@@ -11,11 +11,11 @@ export interface MemberType {
   group: GroupType | null;
   guest?: boolean;
   type?: AuthType;
-  status: StatusType;
+  status?: StatusType;
 }
 
 export interface StatusType {
   level: number;
   exp: number;
-  maximumExp: number;
+  maxExp: number;
 }

--- a/src/utils/types/member.type.ts
+++ b/src/utils/types/member.type.ts
@@ -11,11 +11,11 @@ export interface MemberType {
   group: GroupType | null;
   guest?: boolean;
   type?: AuthType;
-  status?: StatusType;
+  status: StatusType;
 }
 
 export interface StatusType {
   level: number;
   exp: number;
-  maxExp: number;
+  maximumExp: number;
 }

--- a/src/utils/types/member.type.ts
+++ b/src/utils/types/member.type.ts
@@ -11,18 +11,11 @@ export interface MemberType {
   group: GroupType | null;
   guest?: boolean;
   type?: AuthType;
+  status?: StatusType;
 }
 
 export interface StatusType {
   level: number;
   exp: number;
   maxExp: number;
-}
-
-export interface MemberProfileType {
-  id: number;
-  name: string;
-  status: StatusType;
-  type: AuthType;
-  group: GroupType | null;
 }

--- a/src/utils/types/member.type.ts
+++ b/src/utils/types/member.type.ts
@@ -6,19 +6,17 @@ export interface GroupType {
 export type AuthType = 'SOCIAL' | 'GUEST' | 'SELF';
 
 export interface MemberType {
-  member: {
-    id?: number;
-    name?: string;
-    group: GroupType | null;
-    guest?: boolean;
-    type?: AuthType;
-  };
+  id?: number;
+  name?: string;
+  group: GroupType | null;
+  guest?: boolean;
+  type?: AuthType;
 }
 
 export interface StatusType {
   level: number;
   exp: number;
-  maximumExp: number;
+  maxExp: number;
 }
 
 export interface MemberProfileType {

--- a/src/utils/types/member.type.ts
+++ b/src/utils/types/member.type.ts
@@ -17,5 +17,5 @@ export interface MemberType {
 export interface StatusType {
   level: number;
   exp: number;
-  maxExp: number;
+  maximumExp: number;
 }


### PR DESCRIPTION
## 💻 개요

- 리팩토링
- #154 

## 📋 변경 및 추가 사항

- `MemberType`에서 `member`로 한번 묶는 부분을 삭제했습니다. 

  - 서버와 동시에 타입 수정을 하는 게 아니라서 임시로 api 함수의 return문에 삼항 연산자가 들어갔는데요?
  
    이 부분은 서버 수정이 끝나면 `return data;`만 남길 예정입니다


- `MemberType`에 `status` 속성을 추가했습니다

  - 이제 `MemberProfileType`은 `MemberType`과 동일하기 때문에 멸종시켰습니다 
    
    속성이 필수냐 vs 선택이냐 하는 차이가 있긴 했지만!
    프로필은 data가 defined인 게 보장되는 `useSuspenseQuery`로 가져오기 때문에 `MemberType`을 써도 괜찮다고 생각했어욥