### PR TITLE
refactor: `ProfileSection` 컴포넌트를 분리

### DIFF
--- a/src/api/groups.api.ts
+++ b/src/api/groups.api.ts
@@ -1,3 +1,5 @@
+import { MemberType } from '@utils/types/member.type';
+
 import api from './index';
 
 const groupsApi = {
@@ -16,7 +18,7 @@ const groupsApi = {
     return data;
   },
 
-  changeGroupName: async (group: string) => {
+  changeGroupName: async (group: string): Promise<MemberType> => {
     const { data } = await api.put(groupsApi.endPoint.changeName, {
       group,
     });

--- a/src/api/members.api.ts
+++ b/src/api/members.api.ts
@@ -10,8 +10,11 @@ const membersApi = {
     changeMemberImage: '/members/me/profile-image',
   },
 
-  changeMemberName: async (name: string): Promise<void> => {
-    return await api.put(membersApi.endPoint.changeMemberName, { name });
+  changeMemberName: async (name: string): Promise<MemberType> => {
+    const { data } = await api.put(membersApi.endPoint.changeMemberName, {
+      name,
+    });
+    return data;
   },
 
   integrateMember: async (): Promise<MemberType> => {
@@ -24,15 +27,20 @@ const membersApi = {
     return data;
   },
 
-  changeMemberImage: async (profileImage: File) => {
+  changeMemberImage: async (profileImage: File): Promise<MemberType> => {
     const formData = new FormData();
     formData.append('profileImage', profileImage);
 
-    await api.put(membersApi.endPoint.changeMemberImage, formData, {
-      headers: {
-        'Content-Type': 'multipart/form-data',
+    const { data } = await api.put(
+      membersApi.endPoint.changeMemberImage,
+      formData,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
       },
-    });
+    );
+    return data;
   },
 };
 

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -1,0 +1,25 @@
+import Input from './Input';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/Input',
+  component: Input,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof Input>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    fieldLabel: '라벨',
+    valid: true,
+    errorMessage: '에러 메시지',
+  },
+};

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,0 +1,41 @@
+import { ChangeEvent } from 'react';
+
+interface InputProps {
+  fieldLabel?: string;
+  value?: string;
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  list?: string;
+  valid?: boolean;
+  errorMessage?: string;
+}
+
+const Input = ({
+  fieldLabel,
+  value,
+  onChange,
+  list,
+  valid,
+  errorMessage,
+}: InputProps) => {
+  return (
+    <label className={'flex gap-2 text-lg'}>
+      {fieldLabel}
+      <div className={'flex grow flex-col gap-1'}>
+        <input
+          value={value}
+          onChange={onChange}
+          spellCheck={false}
+          list={list}
+          className={
+            'grow rounded-lg border border-primary bg-transparent bg-white px-2 focus:outline-none'
+          }
+        />
+        <span className={`${valid && 'invisible'} px-1 text-sm text-rose-500`}>
+          {errorMessage}
+        </span>
+      </div>
+    </label>
+  );
+};
+
+export default Input;

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -5,7 +5,17 @@ interface useInputProps<T> {
   isInvalid?: (value: T) => boolean;
 }
 
-const useInput = <T>({ initialValue, isInvalid }: useInputProps<T>) => {
+export interface useInputResult<T> {
+  value: T;
+  handleChangeValue: (event: ChangeEvent<HTMLInputElement>) => void;
+  valid: boolean;
+  setFieldValue: (value: T) => void;
+}
+
+const useInput = <T>({
+  initialValue,
+  isInvalid,
+}: useInputProps<T>): useInputResult<T> => {
   const [valid, setValid] = useState<boolean>(
     isInvalid ? isInvalid(initialValue) : true,
   );

--- a/src/pages/user/components/EditImage.tsx
+++ b/src/pages/user/components/EditImage.tsx
@@ -12,31 +12,28 @@ const EditImage = ({
   onClickEdit,
   onChangeFile,
 }: EditImageProps) => {
+  if (isEditing) {
+    return (
+      <label
+        className={`absolute left-2 top-2 h-40 w-40 cursor-pointer rounded-full bg-black bg-opacity-50`}
+      >
+        <input
+          className="hidden"
+          type="file"
+          accept="image/*"
+          onChange={onChangeFile}
+        />
+        <CameraIcon className="mx-auto h-full" />
+      </label>
+    );
+  }
   return (
-    <>
-      {isEditing ? (
-        <label
-          className={`absolute left-2 top-2 h-40 w-40 cursor-pointer rounded-full bg-black bg-opacity-50`}
-        >
-          <input
-            className="hidden"
-            type="file"
-            accept="image/*"
-            onChange={onChangeFile}
-          />
-          <CameraIcon className="mx-auto h-full" />
-        </label>
-      ) : (
-        <button
-          className={
-            'absolute right-2 top-32 h-8 w-8 rounded-full border bg-white'
-          }
-          onClick={onClickEdit}
-        >
-          <EditIcon className={'mx-auto'} />
-        </button>
-      )}
-    </>
+    <button
+      className={'absolute right-2 top-32 h-8 w-8 rounded-full border bg-white'}
+      onClick={onClickEdit}
+    >
+      <EditIcon className={'mx-auto'} />
+    </button>
   );
 };
 

--- a/src/pages/user/components/EditImage.tsx
+++ b/src/pages/user/components/EditImage.tsx
@@ -1,0 +1,43 @@
+import CameraIcon from '@assets/icon/camera.svg?react';
+import EditIcon from '@assets/icon/edit.svg?react';
+
+interface EditImageProps {
+  isEditing: boolean;
+  onClickEdit: () => void;
+  onChangeFile: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const EditImage = ({
+  isEditing,
+  onClickEdit,
+  onChangeFile,
+}: EditImageProps) => {
+  return (
+    <>
+      {isEditing ? (
+        <label
+          className={`absolute left-2 top-2 h-40 w-40 cursor-pointer rounded-full bg-black bg-opacity-50`}
+        >
+          <input
+            className="hidden"
+            type="file"
+            accept="image/*"
+            onChange={onChangeFile}
+          />
+          <CameraIcon className="mx-auto h-full" />
+        </label>
+      ) : (
+        <button
+          className={
+            'absolute right-2 top-32 h-8 w-8 rounded-full border bg-white'
+          }
+          onClick={onClickEdit}
+        >
+          <EditIcon className={'mx-auto'} />
+        </button>
+      )}
+    </>
+  );
+};
+
+export default EditImage;

--- a/src/pages/user/components/EditInfo.tsx
+++ b/src/pages/user/components/EditInfo.tsx
@@ -1,4 +1,5 @@
 import Input from '@components/Input/Input';
+import Spacing from '@components/Spacing/Spacing';
 
 import { useInputResult } from '@hooks/useInput';
 
@@ -27,6 +28,7 @@ const EditInfo = ({
           valid={newName.valid}
           errorMessage={'이름은 2글자 이상, 특수문자를 포함하지 않아야 해요.'}
         />
+        <Spacing size={1} />
         <Input
           fieldLabel={'그룹'}
           value={newGroup.value}

--- a/src/pages/user/components/EditInfo.tsx
+++ b/src/pages/user/components/EditInfo.tsx
@@ -1,0 +1,79 @@
+import Input from '@components/Input/Input';
+
+import { useInputResult } from '@hooks/useInput';
+
+interface EditInfoProps {
+  newName: useInputResult<string>;
+  newGroup: useInputResult<string>;
+  groupSearchResult: string[] | undefined;
+  onClickClose: () => void;
+  onClickDone: () => void;
+}
+
+const EditInfo = ({
+  newName,
+  newGroup,
+  groupSearchResult,
+  onClickClose,
+  onClickDone,
+}: EditInfoProps) => {
+  return (
+    <>
+      <div className={'my-10'}>
+        <Input
+          fieldLabel={'이름'}
+          value={newName.value}
+          onChange={newName.handleChangeValue}
+          valid={newName.valid}
+          errorMessage={'이름은 2글자 이상, 특수문자를 포함하지 않아야 해요.'}
+        />
+        <Input
+          fieldLabel={'그룹'}
+          value={newGroup.value}
+          onChange={newGroup.handleChangeValue}
+          list={'group-list'}
+          valid={newGroup.valid}
+          errorMessage={'그룹은 2글자 이상, 특수문자를 포함하지 않아야 해요.'}
+        />
+        {groupSearchResult && (
+          <datalist id={'group-list'}>
+            {groupSearchResult.map((candidate) => (
+              <option
+                className={
+                  'cursor-pointer rounded-lg px-2 py-1 hover:bg-slate-100'
+                }
+                key={candidate}
+                value={candidate}
+                onClick={() => {
+                  newGroup.setFieldValue(candidate);
+                }}
+              ></option>
+            ))}
+          </datalist>
+        )}
+      </div>
+
+      <div className={'flex gap-2'}>
+        <button
+          onClick={onClickClose}
+          className={
+            'rounded-md border bg-white px-4 py-1 hover:bg-white hover:text-black '
+          }
+        >
+          닫기
+        </button>
+        <button
+          disabled={!newName.valid || !newGroup.valid}
+          onClick={onClickDone}
+          className={
+            'rounded-md bg-button-enabled px-4 py-1 text-white disabled:cursor-not-allowed disabled:bg-button-disabled disabled:opacity-100'
+          }
+        >
+          확인
+        </button>
+      </div>
+    </>
+  );
+};
+
+export default EditInfo;

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -55,36 +55,44 @@ const ProfileSection = ({
     target: newGroup.value,
     delay: 300,
   });
+
   const { data } = useGetGroupsNames({
     startWidth: debounceValue,
     enabled: !!debounceValue,
   });
 
   const setUserState = useSetRecoilState(userState);
-
   const queryClient = useQueryClient();
 
   const changeUserName = useChangeUserName();
   const changeGroupName = useChangeGroupName();
   const changeUserImage = useChangeUserImage();
 
-  const handleClickDone = async () => {
+  const handleProfileChange = async () => {
+    let newProfile = undefined;
+
     if (profile.name !== newName.value) {
-      await changeUserName.mutateAsync(newName.value);
+      newProfile = await changeUserName.mutateAsync(newName.value);
     }
     if (profile.group?.name !== newGroup.value) {
-      await changeGroupName.mutateAsync(newGroup.value);
+      newProfile = await changeGroupName.mutateAsync(newGroup.value);
     }
     if (newImageFile !== null) {
-      await changeUserImage.mutateAsync(newImageFile);
+      newProfile = await changeUserImage.mutateAsync(newImageFile);
+      setNewImageFile(null);
     }
 
-    setUserState((prevInfo) => ({
-      ...prevInfo,
-      name: newName.value,
-      group: { name: newGroup.value },
-    }));
-    queryClient.invalidateQueries({ queryKey: [QUERY_KEY.USER_PROFILE] });
+    return newProfile;
+  };
+
+  const handleClickDone = async () => {
+    const newProfile = await handleProfileChange();
+
+    if (newProfile) {
+      setUserState({ ...newProfile });
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY.USER_PROFILE] });
+    }
+
     onClickDone();
   };
 

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -6,6 +6,7 @@ import { useSetRecoilState } from 'recoil';
 import CameraIcon from '@assets/icon/camera.svg?react';
 import EditIcon from '@assets/icon/edit.svg?react';
 import Button from '@components/Button/Button';
+import Input from '@components/Input/Input';
 import { userState } from '@utils/atoms/member.atom';
 import { MemberType } from '@utils/types/member.type';
 
@@ -141,49 +142,26 @@ const ProfileSection = ({
       {isEditing ? (
         <>
           <div className={'my-10'}>
-            <label className={'flex gap-2 text-lg'}>
-              이름
-              <div className={'flex grow flex-col gap-1'}>
-                <input
-                  value={newName}
-                  onChange={handleNameChange}
-                  spellCheck={false}
-                  className={
-                    'grow rounded-lg border border-primary bg-transparent bg-white px-2 focus:outline-none'
-                  }
-                />
+            <Input
+              fieldLabel={'이름'}
+              value={newName}
+              onChange={handleNameChange}
+              valid={nameValid}
+              errorMessage={
+                '이름은 2글자 이상, 특수문자를 포함하지 않아야 해요.'
+              }
+            />
 
-                <span
-                  className={`${
-                    nameValid && 'invisible'
-                  } mb-4 px-1 text-sm text-rose-500`}
-                >
-                  이름은 2글자 이상, 특수문자를 포함하지 않아야 해요.
-                </span>
-              </div>
-            </label>
-
-            <label className={'flex gap-2 text-lg'}>
-              그룹
-              <div className={'flex grow flex-col gap-1'}>
-                <input
-                  list={'group-list'}
-                  value={newGroup}
-                  onChange={handleGroupChange}
-                  spellCheck={false}
-                  className={
-                    'grow rounded-lg border border-primary bg-transparent bg-white px-2 focus:outline-none'
-                  }
-                />
-                <span
-                  className={`${
-                    groupValid && 'invisible'
-                  } px-1 text-sm text-rose-500`}
-                >
-                  그룹은 2글자 이상, 특수문자를 포함하지 않아야 해요.
-                </span>
-              </div>
-            </label>
+            <Input
+              fieldLabel={'그룹'}
+              value={newGroup}
+              onChange={handleGroupChange}
+              list={'group-list'}
+              valid={groupValid}
+              errorMessage={
+                '그룹은 2글자 이상, 특수문자를 포함하지 않아야 해요.'
+              }
+            />
             {data && (
               <datalist id={'group-list'}>
                 {data.map((candidate) => (

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -3,8 +3,6 @@ import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSetRecoilState } from 'recoil';
 
-import CameraIcon from '@assets/icon/camera.svg?react';
-import EditIcon from '@assets/icon/edit.svg?react';
 import Button from '@components/Button/Button';
 import Input from '@components/Input/Input';
 import { userState } from '@utils/atoms/member.atom';
@@ -23,6 +21,7 @@ import {
 import useDebounce from '@hooks/useDebounce';
 import useInput from '@hooks/useInput';
 
+import EditImage from './EditImage';
 import ExpChart from './ExpChart';
 
 interface ProfileSectionProps {
@@ -115,30 +114,13 @@ const ProfileSection = ({
           }
           src={newImage || profile.profileImage}
         />
-
-        {!isEditing ? (
-          <button
-            className={
-              'absolute right-2 top-32 h-8 w-8 rounded-full border bg-white'
-            }
-            onClick={onClickEdit}
-          >
-            <EditIcon className={'mx-auto'} />
-          </button>
-        ) : (
-          <label
-            className={`absolute left-2 top-2 h-40 w-40 cursor-pointer rounded-full bg-black bg-opacity-50`}
-          >
-            <input
-              className="hidden"
-              type="file"
-              accept="image/*"
-              onChange={handleFileChange}
-            />
-            <CameraIcon className="mx-auto h-full" />
-          </label>
-        )}
+        <EditImage
+          isEditing={isEditing}
+          onClickEdit={onClickEdit}
+          onChangeFile={handleFileChange}
+        />
       </div>
+
       {isEditing ? (
         <>
           <div className={'my-10'}>

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -68,6 +68,13 @@ const ProfileSection = ({
   const changeGroupName = useChangeGroupName();
   const changeUserImage = useChangeUserImage();
 
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files !== null) {
+      setNewImageFile(event.target.files[0]);
+      setNewImage(URL.createObjectURL(event.target.files[0]));
+    }
+  };
+
   const handleProfileChange = async () => {
     let newProfile = undefined;
 
@@ -94,13 +101,6 @@ const ProfileSection = ({
     }
 
     onClickDone();
-  };
-
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.files !== null) {
-      setNewImageFile(event.target.files[0]);
-      setNewImage(URL.createObjectURL(event.target.files[0]));
-    }
   };
 
   return (

--- a/src/pages/user/components/UserInfo.tsx
+++ b/src/pages/user/components/UserInfo.tsx
@@ -10,15 +10,15 @@ const UserInfo = () => {
   const profile = useGetMemberProfile();
   const [isEditing, setIsEditing] = useState(false);
 
-  const onClickEdit = () => {
+  const handleClickEdit = () => {
     setIsEditing(true);
   };
 
-  const onClickDone = () => {
+  const handleClickDone = () => {
     setIsEditing(false);
   };
 
-  const onClickClose = () => {
+  const handleClickClose = () => {
     setIsEditing(false);
   };
 
@@ -35,9 +35,9 @@ const UserInfo = () => {
           <ProfileSection
             profile={profile}
             isEditing={isEditing}
-            onClickEdit={onClickEdit}
-            onClickDone={onClickDone}
-            onClickClose={onClickClose}
+            onClickEdit={handleClickEdit}
+            onClickDone={handleClickDone}
+            onClickClose={handleClickClose}
           />
         )}
         <Spacing size={16} />


### PR DESCRIPTION
## 💻 개요

- 리팩토링

- #163 

## 📋 변경 및 추가 사항

- `ProfileSection`에서 profileImage 편집 / name, group 편집에 대한 부분을 user 폴더 하위 컴포넌트로 분리했습니다

  - name, group 편집 컴포넌트 `EditInfo`에서 useInput 훅의 리턴 값을 **객체로 받아서** 사용합니다
    newName, nameValid, .. 이런 식으로 하나하나 받으려면 인자가 너무 많아져서 이렇게 해봤어요!!
    그런고로,, useInput의 리턴 타입을 정의해서 사용했습니다

- name, group 편집에 사용되는 `Input` 컴포넌트를 common 폴더 하위 컴포넌트로 분리했습니다

## 💬 To. 리뷰어
- 원래 `ProfileSection`을 조회 / 편집 두 종류의 컴포넌트로 쪼개려다가 편집 컴포넌트 분리하고 나니까
  조회는 굳이 분리 안 해도 될 크기라서 고냥 `ProfileSection` 안에 냅뒀습니다......!!

<details>
<summary> profileImage 관련 논의 </summary>

- 로컬 스토리지 `profileImage`는 업데이트 되지 않는데 괜찮을까요 이거

  프로필 이미지 업데이트 시 s3 버킷 주소가 응답으로 오진 않음
  ➡ 프로필 수정해도 localStorage에 이전 프로필 이미지 주소가 남아있음
       (업데이트 완료하면 서버에 요청을 한번 더 보내니까 바뀐 정보가 바로 보이지만)
 
  🤔 지금은 로컬 스토리지에 있는 `profileImage`를 쓰는 곳이 없어서 문제가 없긴 합니다

  - 근데 랭킹에서 이미지를 쓰게 된다면?!?!?! 
    RankOwnerResponse에 `profileImage` 속성을 추가해서 해결할 수도 있을 거 같긴 한디. 흠.
    ![image](https://github.com/snack-game/front/assets/87255462/ce1497ac-4fb6-4f46-8c30-06257315f11b)
</details>
