### PR TITLE
feat: 랭킹 페이지 사용자 level 표시, 시즌제 도입

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import { RecoilRoot } from 'recoil';
 import { BrowserRouter } from 'react-router-dom';
 import '../index.css';
 import { HelmetProvider } from 'react-helmet-async';
+import React from 'react';
 
 export const decorators = [
   // @ts-ignore

--- a/src/api/ranking.api.ts
+++ b/src/api/ranking.api.ts
@@ -1,10 +1,15 @@
 import api from '@api/index';
+import { RankingType } from '@utils/types/common.type';
 
 const rankingApi = {
   endPoint: {
     totalRanking: '/rankings?by=BEST_SCORE',
     userRanking: '/rankings/me?by=BEST_SCORE',
+
+    seasonRanking: '/rankings',
+    seasonRankingMe: '/rankings',
   },
+
   headers: {
     'Content-Type': 'application/json',
     Accept: 'application/json',
@@ -17,6 +22,20 @@ const rankingApi = {
 
   userRanking: async () => {
     const { data } = await api.get(rankingApi.endPoint.userRanking);
+    return data;
+  },
+
+  seasonRanking: async (season: number): Promise<RankingType[]> => {
+    const { data } = await api.get(
+      `${rankingApi.endPoint.seasonRanking}/${season}?by=BEST_SCORE`,
+    );
+    return data;
+  },
+
+  seasonRankingMe: async (season: number) => {
+    const { data } = await api.get(
+      `${rankingApi.endPoint.seasonRankingMe}/${season}/me?by=BEST_SCORE`,
+    );
     return data;
   },
 };

--- a/src/assets/icon/down-arrow.svg
+++ b/src/assets/icon/down-arrow.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 10L12 15L17 10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/DropDown/DropDown.stories.tsx
+++ b/src/components/DropDown/DropDown.stories.tsx
@@ -38,6 +38,6 @@ export const Default: Story = {
         },
       },
     ],
-    initalOption: 0,
+    initialOption: 0,
   },
 };

--- a/src/components/DropDown/DropDown.stories.tsx
+++ b/src/components/DropDown/DropDown.stories.tsx
@@ -1,0 +1,43 @@
+import DropDown from './DropDown';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/DropDown',
+  component: DropDown,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof DropDown>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    options: [
+      {
+        name: 'good',
+        onClick: () => {
+          return;
+        },
+      },
+      {
+        name: 'bed',
+        onClick: () => {
+          return;
+        },
+      },
+      {
+        name: 'bed',
+        onClick: () => {
+          return;
+        },
+      },
+    ],
+    mainContent: '응가',
+  },
+};

--- a/src/components/DropDown/DropDown.stories.tsx
+++ b/src/components/DropDown/DropDown.stories.tsx
@@ -38,6 +38,6 @@ export const Default: Story = {
         },
       },
     ],
-    mainContent: '응가',
+    initalOption: 0,
   },
 };

--- a/src/components/DropDown/DropDown.tsx
+++ b/src/components/DropDown/DropDown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { motion } from 'framer-motion';
 

--- a/src/components/DropDown/DropDown.tsx
+++ b/src/components/DropDown/DropDown.tsx
@@ -13,17 +13,17 @@ export type DropDownOptionType = {
 interface DropDownProps {
   options: DropDownOptionType[];
   className?: string;
-  initalOption?: number;
+  initialOption?: number;
 }
 
 export default function Dropdown({
   options,
   className,
-  initalOption,
+  initialOption,
 }: DropDownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [mainContentState, setMainContentState] = useState<string>(
-    (initalOption && options[initalOption].name) || options[0].name,
+    (initialOption && options[initialOption].name) || options[0].name,
   );
 
   const handleClickOption = (option: DropDownOptionType) => {

--- a/src/components/DropDown/DropDown.tsx
+++ b/src/components/DropDown/DropDown.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { motion } from 'framer-motion';
 
@@ -7,31 +7,41 @@ import DownArrow from '@assets/icon/down-arrow.svg?react';
 export type DropDownOptionType = {
   name: string;
   onClick: () => void;
+  value?: string | number;
 };
 
 interface DropDownProps {
   options: DropDownOptionType[];
   className?: string;
-  mainContent: string;
+  initalOption?: number;
 }
 
 export default function Dropdown({
   options,
   className,
-  mainContent,
+  initalOption,
 }: DropDownProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [mainContentState, setMainContentState] = useState<string>(
+    (initalOption && options[initalOption].name) || options[0].name,
+  );
+
+  const handleClickOption = (option: DropDownOptionType) => {
+    setMainContentState(option.name);
+    option.onClick();
+    setIsOpen(false);
+  };
 
   return (
-    <div className={`${className}`}>
-      <div className={'relative'} onClick={() => setIsOpen(!isOpen)}>
+    <div className={className}>
+      <div className="relative" onClick={() => setIsOpen(!isOpen)}>
         <motion.div
           className="flex cursor-pointer justify-around rounded-md bg-primary px-3 py-2 text-white"
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.95 }}
         >
-          <p>{mainContent}</p>
-          <DownArrow className={'h-6 w-6'} />
+          <p>{mainContentState}</p>
+          <DownArrow className="h-6 w-6" />
         </motion.div>
       </div>
       {isOpen && (
@@ -39,10 +49,8 @@ export default function Dropdown({
           {options.map((option) => (
             <motion.div
               key={option.name}
-              className={
-                'hover:bg-brand-colo px-5 py-4 text-primary-dark hover:rounded-md hover:bg-primary hover:text-white'
-              }
-              onClick={option.onClick}
+              className="hover:bg-brand-colo px-5 py-4 text-primary-dark hover:rounded-md hover:bg-primary hover:text-white"
+              onClick={() => handleClickOption(option)}
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
             >

--- a/src/components/DropDown/DropDown.tsx
+++ b/src/components/DropDown/DropDown.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+
+import { motion } from 'framer-motion';
+
+import DownArrow from '@assets/icon/down-arrow.svg?react';
+
+export type DropDownOptionType = {
+  name: string;
+  onClick: () => void;
+};
+
+interface DropDownProps {
+  options: DropDownOptionType[];
+  className?: string;
+  mainContent: string;
+}
+
+export default function Dropdown({
+  options,
+  className,
+  mainContent,
+}: DropDownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className={`${className}`}>
+      <div className={'relative'} onClick={() => setIsOpen(!isOpen)}>
+        <motion.div
+          className="flex cursor-pointer justify-around rounded-md bg-primary px-3 py-2 text-white"
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+        >
+          <p>{mainContent}</p>
+          <DownArrow className={'h-6 w-6'} />
+        </motion.div>
+      </div>
+      {isOpen && (
+        <div className="absolute mt-1 min-w-[150px] divide-y-2 rounded-md border-2 border-primary bg-white">
+          {options.map((option) => (
+            <motion.div
+              key={option.name}
+              className={
+                'hover:bg-brand-colo px-5 py-4 text-primary-dark hover:rounded-md hover:bg-primary hover:text-white'
+              }
+              onClick={option.onClick}
+              whileHover={{ scale: 1.05 }}
+              whileTap={{ scale: 0.95 }}
+            >
+              {option.name}
+            </motion.div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Level/Level.stories.tsx
+++ b/src/components/Level/Level.stories.tsx
@@ -1,0 +1,23 @@
+import { Level } from './Level';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'components/Level',
+  component: Level,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof Level>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    level: 20,
+  },
+};

--- a/src/components/Level/Level.tsx
+++ b/src/components/Level/Level.tsx
@@ -1,0 +1,18 @@
+import { TIER_COLOR } from '@constants/tier.constant';
+
+interface LevelProps {
+  level: number;
+}
+
+export const Level = ({ level }: LevelProps) => {
+  const tier = Math.floor(level / 10);
+
+  return (
+    <div
+      className={`flex h-5 w-5 items-center justify-center rounded-full text-sm text-white`}
+      style={{ backgroundColor: TIER_COLOR[tier] }}
+    >
+      {level}
+    </div>
+  );
+};

--- a/src/constants/api.constant.ts
+++ b/src/constants/api.constant.ts
@@ -5,6 +5,9 @@ export const QUERY_KEY = {
   USER_RANKING: 'userRanking',
 
   USER_PROFILE: 'userProfile',
+
+  SEASON_RANKING: 'seasonRanking',
+  SEASON_USER_RANKING: 'seasonUserRanking',
 };
 
 export interface ServerError {

--- a/src/hooks/queries/ranking.query.ts
+++ b/src/hooks/queries/ranking.query.ts
@@ -28,3 +28,21 @@ export const useGetUserRanking = () => {
 
   return data;
 };
+
+export const useGetSeasonRanking = (season: number) => {
+  const { data } = useSuspenseQuery<RankingType[], AxiosError>({
+    queryKey: [QUERY_KEY.SEASON_RANKING, season],
+    queryFn: () => rankingApi.seasonRanking(season),
+  });
+
+  return data;
+};
+
+export const useGetSeasonRankingMe = (season: number) => {
+  const { data } = useSuspenseQuery<RankingType, AxiosError>({
+    queryKey: [QUERY_KEY.SEASON_USER_RANKING, season],
+    queryFn: () => rankingApi.seasonRankingMe(season),
+  });
+
+  return data;
+};

--- a/src/pages/games/AppleGame/RankingPage.tsx
+++ b/src/pages/games/AppleGame/RankingPage.tsx
@@ -31,7 +31,7 @@ const RankingPage = () => {
       <Spacing size={2} />
       <div className="mx-auto w-[90%] max-w-4xl">
         <Dropdown
-          initalOption={1}
+          initialOption={1}
           options={dropdownOptions}
           className="max-w-[120px]"
         />

--- a/src/pages/games/AppleGame/RankingPage.tsx
+++ b/src/pages/games/AppleGame/RankingPage.tsx
@@ -1,12 +1,26 @@
-import React from 'react';
+import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 
+import Dropdown, { DropDownOptionType } from '@components/DropDown/DropDown';
 import Footer from '@components/Footer/Footer';
 import Spacing from '@components/Spacing/Spacing';
 import AppleGameHeader from '@pages/games/AppleGame/components/AppleGameHeader';
 import RankingSection from '@pages/games/AppleGame/components/RankingSection';
 
 const RankingPage = () => {
+  const [selectedSeason, setSelectedSeason] = useState<number>(1);
+
+  const dropdownOptions: DropDownOptionType[] = [
+    {
+      name: '전체',
+      onClick: () => setSelectedSeason(0),
+    },
+    {
+      name: '시즌 1',
+      onClick: () => setSelectedSeason(1),
+    },
+  ];
+
   return (
     <>
       <Helmet>
@@ -14,8 +28,16 @@ const RankingPage = () => {
       </Helmet>
 
       <AppleGameHeader />
+      <Spacing size={2} />
+      <div className="mx-auto w-[90%] max-w-4xl">
+        <Dropdown
+          initalOption={1}
+          options={dropdownOptions}
+          className="max-w-[120px]"
+        />
+      </div>
       <Spacing size={8} />
-      <RankingSection />
+      <RankingSection season={selectedSeason} />
       <Footer />
     </>
   );

--- a/src/pages/games/AppleGame/components/OtherRanking.tsx
+++ b/src/pages/games/AppleGame/components/OtherRanking.tsx
@@ -18,10 +18,10 @@ const OtherRanking = ({ otherRanking }: OtherRankingProps) => {
         </tr>
       </thead>
       <motion.tbody>
-        {otherRanking.map((rank) => {
+        {otherRanking.map((rank, index) => {
           return (
             <motion.tr
-              key={rank.owner.name}
+              key={`rank-${index}-${rank.owner.name}`}
               className={'h-24 border-b-2 border-b-gray-200 font-semibold'}
               initial={{ y: -40, opacity: 0 }}
               whileInView={{ y: 0, opacity: 1 }}

--- a/src/pages/games/AppleGame/components/OtherRanking.tsx
+++ b/src/pages/games/AppleGame/components/OtherRanking.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 
+import { Level } from '@components/Level/Level';
 import { RankingType } from '@utils/types/common.type';
 
 interface OtherRankingProps {
@@ -33,9 +34,14 @@ const OtherRanking = ({ otherRanking }: OtherRankingProps) => {
                   <span className={'text-xs'}>
                     {rank.owner.group && rank.owner.group.name}
                   </span>
-                  <span className={'text-lg text-primary'}>
-                    {rank.owner.name}
-                  </span>
+                  <div className="flex items-center gap-2">
+                    <span className={'text-lg text-primary'}>
+                      {rank.owner.name}
+                    </span>
+                    {rank.owner.status?.level !== undefined && (
+                      <Level level={rank.owner.status.level} />
+                    )}
+                  </div>
                 </div>
               </td>
               <td className={'text-center'}>{rank.score}</td>

--- a/src/pages/games/AppleGame/components/RankingSection.tsx
+++ b/src/pages/games/AppleGame/components/RankingSection.tsx
@@ -4,13 +4,27 @@ import OtherRanking from '@pages/games/AppleGame/components/OtherRanking';
 import TopRanking from '@pages/games/AppleGame/components/TopRanking';
 import { userState } from '@utils/atoms/member.atom';
 
-import { useGetTotalRanking } from '@hooks/queries/ranking.query';
+import {
+  useGetSeasonRanking,
+  useGetTotalRanking,
+} from '@hooks/queries/ranking.query';
 
 import UserRanking from './UserRanking';
 
-const RankingSection = () => {
-  const totalRanking = useGetTotalRanking();
+interface RankingSectionProps {
+  season: number;
+}
+
+const RankingSection = ({ season }: RankingSectionProps) => {
+  let totalRanking;
+
   const userInfo = useRecoilValue(userState);
+
+  if (season === 0) {
+    totalRanking = useGetTotalRanking();
+  } else {
+    totalRanking = useGetSeasonRanking(season);
+  }
 
   const topRanking = totalRanking?.slice(0, 3);
   const otherRanking = totalRanking?.slice(3);
@@ -19,7 +33,7 @@ const RankingSection = () => {
     <div className={'mx-auto w-full max-w-4xl'}>
       {topRanking && <TopRanking topRanking={topRanking} />}
       {otherRanking && <OtherRanking otherRanking={otherRanking} />}
-      {userInfo.id && <UserRanking />}
+      {userInfo.id && <UserRanking season={season} />}
     </div>
   );
 };

--- a/src/pages/games/AppleGame/components/TopRanking.tsx
+++ b/src/pages/games/AppleGame/components/TopRanking.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import First from '@assets/images/first.png';
 import Second from '@assets/images/second.png';
 import Third from '@assets/images/third.png';
+import { Level } from '@components/Level/Level';
 import { RankingType } from '@utils/types/common.type';
 
 interface TopRankingProps {
@@ -46,6 +47,9 @@ const TopRanking = ({ topRanking }: TopRankingProps) => {
                   </span>
                 )}
                 <span className={'text-xl text-primary'}>{top.owner.name}</span>
+                {top.owner.status?.level !== undefined && (
+                  <Level level={top.owner.status.level} />
+                )}
               </div>
               <span>{top.score + '점'}</span>
             </div>

--- a/src/pages/games/AppleGame/components/TopRanking.tsx
+++ b/src/pages/games/AppleGame/components/TopRanking.tsx
@@ -28,7 +28,7 @@ const TopRanking = ({ topRanking }: TopRankingProps) => {
       {topRanking.map((top, index) => {
         return (
           <div
-            key={top.rank}
+            key={`top-rank-${top.owner.name}`}
             className={`flex flex-col items-center gap-4 font-semibold text-primary-deep-dark
             ${index == 0 && 'order-2 -mt-12'}
             ${index == 1 && 'order-1'}

--- a/src/pages/games/AppleGame/components/UserRanking.tsx
+++ b/src/pages/games/AppleGame/components/UserRanking.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { Level } from '@components/Level/Level';
 
 import { useGetUserRanking } from '@hooks/queries/ranking.query';
 
@@ -10,7 +10,12 @@ const UserRanking = () => {
       <div className="flex h-full w-full items-center justify-around">
         <div className="flex flex-col">
           <div className="text-xs">{userRanking?.owner.group?.name}</div>
-          <div className="text-primary">{userRanking?.owner.name}</div>
+          <div className="flex items-center gap-2">
+            <div className="text-primary">{userRanking?.owner.name}</div>
+            {userRanking?.owner.status?.level !== undefined && (
+              <Level level={userRanking.owner.status.level} />
+            )}
+          </div>
         </div>
         <div>{userRanking?.score} 점</div>
         <div>{userRanking?.rank} 등!</div>

--- a/src/pages/games/AppleGame/components/UserRanking.tsx
+++ b/src/pages/games/AppleGame/components/UserRanking.tsx
@@ -1,9 +1,22 @@
 import { Level } from '@components/Level/Level';
 
-import { useGetUserRanking } from '@hooks/queries/ranking.query';
+import {
+  useGetSeasonRankingMe,
+  useGetUserRanking,
+} from '@hooks/queries/ranking.query';
 
-const UserRanking = () => {
-  const userRanking = useGetUserRanking();
+interface UserRankingProps {
+  season: number;
+}
+
+const UserRanking = ({ season }: UserRankingProps) => {
+  let userRanking;
+
+  if (season === 0) {
+    userRanking = useGetUserRanking();
+  } else {
+    userRanking = useGetSeasonRankingMe(season);
+  }
 
   return (
     <div className="fixed bottom-5 left-1/2 w-[90%] -translate-x-1/2 rounded-full border-2 border-primary bg-primary-light px-6 py-3 text-primary-deep-dark lg:w-1/3">

--- a/src/utils/types/common.type.ts
+++ b/src/utils/types/common.type.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { AnimationItem } from 'lottie-web';
 
-import { GroupType } from '@utils/types/member.type';
+import { GroupType, MemberType } from '@utils/types/member.type';
 
 export type ToastType = 'success' | 'error' | 'loading' | 'info' | 'warning';
 
@@ -31,11 +31,7 @@ export type LottieOptionTypes = {
 
 export type RankingType = {
   rank: number;
-  owner: {
-    id: number;
-    name: string;
-    group: GroupType | null;
-  };
+  owner: MemberType;
   score: number;
   message?: string;
 };


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 신규 피처
- #166 
- #151 

## 📋 변경 및 추가 사항

### 랭킹 페이지에 시즌별 랭킹 조회 기능을 추가했습니다.
11ca464dade75ad462a028ac9dd3e1ce6a9e8f61

## level, dropdown 컴포넌트 추가
level을 표시하기 위해 ranking 페이지용 level 컴포넌트와 
dropdown 컴포넌트가 추가되었습니다. 
기존 RankingType의 중복 영역을 대체했습니다.
```tsx
export type RankingType = {
  rank: number;
  owner: {
    id: number;
    name: string;
    group: GroupType | null;
  };
  score: number;
  message?: string;
};

to

owner: MemberType;
```

DropDown 컴포넌트는 
DropDownOptionType[]을 전달받아 name을 option에 렌더링 합니다. 초기에 보여줄 컨텐츠를 initalOption Prop을 전달이 가능하고 따로 설정하지 않으면 옵션중 첫 번째 값 [0]이 선택됩니다.
```tsx
export type DropDownOptionType = {
  name: string;
  onClick: () => void;
  value?: string | number;
};
```
DropDownOptionType에 명시된 대로 각 option이 선택되었을 때 수행할 로직을 onClick을 통해 전달하고 DropDown컴포넌트는 사용자가 option 선택 시 해당 handleClickOption함수에서 자신의 상태를 변경하고 전달 받은 로직을 수행합니다.

ccb430426014368c88d2e24bdabe7d39961b0c67

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
