### PR TITLE
fix: 개발환경 ga 제거, rankingpage user ranking 분기문 수정

### DIFF
--- a/.github/workflows/ci-development.yml
+++ b/.github/workflows/ci-development.yml
@@ -1,7 +1,7 @@
-name: Deploy CI
+name: Deploy Development CI
 on:
   push:
-    branches: [master]
+    branches: [develop]
 
 jobs:
   deploy:
@@ -15,4 +15,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DEV_PROJECT_ID }}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,6 +25,7 @@ const queryClient = new QueryClient({
 
 const Root = () => {
   useEffect(() => {
+    if (!import.meta.env.VITE_GA_TRACKING_ID) return;
     ReactGA.initialize(import.meta.env.VITE_GA_TRACKING_ID);
   }, []);
 

--- a/src/pages/games/AppleGame/components/RankingSection.tsx
+++ b/src/pages/games/AppleGame/components/RankingSection.tsx
@@ -33,7 +33,9 @@ const RankingSection = ({ season }: RankingSectionProps) => {
     <div className={'mx-auto w-full max-w-4xl'}>
       {topRanking && <TopRanking topRanking={topRanking} />}
       {otherRanking && <OtherRanking otherRanking={otherRanking} />}
-      {userInfo.id && <UserRanking season={season} />}
+      {userInfo.id && userInfo.type !== 'GUEST' && (
+        <UserRanking season={season} />
+      )}
     </div>
   );
 };

--- a/src/pages/games/AppleGame/components/RankingSection.tsx
+++ b/src/pages/games/AppleGame/components/RankingSection.tsx
@@ -33,9 +33,7 @@ const RankingSection = ({ season }: RankingSectionProps) => {
     <div className={'mx-auto w-full max-w-4xl'}>
       {topRanking && <TopRanking topRanking={topRanking} />}
       {otherRanking && <OtherRanking otherRanking={otherRanking} />}
-      {userInfo.id && userInfo.type !== 'GUEST' && (
-        <UserRanking season={season} />
-      )}
+      {userInfo.type !== 'GUEST' && <UserRanking season={season} />}
     </div>
   );
 };


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 이슈대응
- #174 

## 📋 변경 및 추가 사항
### 개발환경 ga 제거
프론트 개발버전 베포  환경에서 ga tag id를 로딩하려고 하여 환경변수가 없으면 로딩하지 않도록 했습니다.
### rankingpage user ranking 분기문 수정
ranking page에서 user ranking의 분기문을 user id가 존재 여부에 따라 렌더링 여부를 결정했는데 게스트 유저도 user id가 존재하기 때문에 user ranking api 요청시 401 오류가 발생하는 부분을 수정했습니다.

5c6da33412893fdd97aaa2ea5ae4efd54b37dfd7

### 개발환경 베포 스크립트를 추가했습니다. 
git을 연결해두면 거의 모든 활동에 preview 베포를 진행하기 때문에 불필요한 베포를 제거하고 효율적으로 수행하기 위해 vercel과 레포지토리 연동을 끊고 action에서 베포합니다.
9ce74db365d04c3963566006ff7815f9f72fc495
## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
