### PR TITLE
fix: path.constant 하드코딩된 url 제거 base url기준으로 oauth 요청

### DIFF
--- a/src/components/Auth/OAuth.tsx
+++ b/src/components/Auth/OAuth.tsx
@@ -33,6 +33,7 @@ const OAuth = ({ oAuthOnSuccess }: OAuthContainerProps) => {
   const openToast = useToast();
 
   const openOAuthDialog = ({ url, name }: DialogProps) => {
+    const oAuthURL = import.meta.env.VITE_API_URL + url;
     const width = 600;
     const height = 800;
 
@@ -40,7 +41,7 @@ const OAuth = ({ oAuthOnSuccess }: OAuthContainerProps) => {
     const top = (window.screen.height - height) / 2;
 
     window.open(
-      url,
+      oAuthURL,
       name,
       `menubar=no,toolbar=no,status=no,width=${width},height=${height},left=${left},top=${top}`,
     );

--- a/src/constants/path.constant.ts
+++ b/src/constants/path.constant.ts
@@ -17,8 +17,8 @@ const PATH = {
   FEED_BACK:
     'https://docs.google.com/forms/d/e/1FAIpQLScYLV4AQccEoAlcSo1fC9_1-7gC3KYR1lnOGJ7Xtqm5DPBbHg/viewform?usp=sharing',
 
-  GOOGLE: 'https://api.snackga.me/oauth2/authorization/google',
-  KAKAO: 'https://api.snackga.me/oauth2/authorization/kakao',
+  GOOGLE: 'oauth2/authorization/google',
+  KAKAO: 'oauth2/authorization/kakao',
 
   OAUTH_SUCCESS: '/oauth/success',
   OAUTH_FAILURE: '/oauth/failure',

--- a/src/pages/games/AppleGame/components/RankingSection.tsx
+++ b/src/pages/games/AppleGame/components/RankingSection.tsx
@@ -33,7 +33,9 @@ const RankingSection = ({ season }: RankingSectionProps) => {
     <div className={'mx-auto w-full max-w-4xl'}>
       {topRanking && <TopRanking topRanking={topRanking} />}
       {otherRanking && <OtherRanking otherRanking={otherRanking} />}
-      {userInfo.type !== 'GUEST' && <UserRanking season={season} />}
+      {userInfo.type && userInfo.type !== 'GUEST' && (
+        <UserRanking season={season} />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 이슈 대응
- #177 

## 📋 변경 및 추가 사항

### path.constant 하드코딩된 url 제거
baseURL 기준으로 API요청을 보내지 않고 하드코딩 되어있던 url 때문에 개발 버전에서 프로덕션 환경 서버로 요청을 보내는 이슈가 있었습니다.
해당 URL 부분을 제거하고 oAuth 요청 url을 다음과 같이 동적으로 적용할 수 있도록 변경했습니다.
```typescript
const oAuthURL = import.meta.env.VITE_API_URL + url;
```

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
