### PR TITLE
refactor: `useGetGroupsNames` `useDebounce`를 `EditInfo` 컴포넌트로 이동

### DIFF
--- a/src/pages/user/components/EditInfo.tsx
+++ b/src/pages/user/components/EditInfo.tsx
@@ -1,12 +1,13 @@
 import Input from '@components/Input/Input';
 import Spacing from '@components/Spacing/Spacing';
 
+import { useGetGroupsNames } from '@hooks/queries/groups.query';
+import useDebounce from '@hooks/useDebounce';
 import { useInputResult } from '@hooks/useInput';
 
 interface EditInfoProps {
   newName: useInputResult<string>;
   newGroup: useInputResult<string>;
-  groupSearchResult: string[] | undefined;
   onClickClose: () => void;
   onClickDone: () => void;
 }
@@ -14,10 +15,19 @@ interface EditInfoProps {
 const EditInfo = ({
   newName,
   newGroup,
-  groupSearchResult,
   onClickClose,
   onClickDone,
 }: EditInfoProps) => {
+  const debounceValue = useDebounce({
+    target: newGroup.value,
+    delay: 300,
+  });
+
+  const { data: groupSearchResult } = useGetGroupsNames({
+    startWidth: debounceValue,
+    enabled: !!debounceValue,
+  });
+
   return (
     <>
       <div className={'my-10'}>

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -8,15 +8,11 @@ import { MemberType } from '@utils/types/member.type';
 
 import { QUERY_KEY } from '@constants/api.constant';
 import { GROUP_CHANGE_REGEXP, NAME_REGEXP } from '@constants/regexp.constant';
-import {
-  useChangeGroupName,
-  useGetGroupsNames,
-} from '@hooks/queries/groups.query';
+import { useChangeGroupName } from '@hooks/queries/groups.query';
 import {
   useChangeUserImage,
   useChangeUserName,
 } from '@hooks/queries/members.query';
-import useDebounce from '@hooks/useDebounce';
 import useInput from '@hooks/useInput';
 
 import EditImage from './EditImage';
@@ -49,16 +45,6 @@ const ProfileSection = ({
   const newGroup = useInput<string>({
     initialValue: profile.group?.name || '',
     isInvalid: (group) => GROUP_CHANGE_REGEXP.test(group),
-  });
-
-  const debounceValue = useDebounce({
-    target: newGroup.value,
-    delay: 300,
-  });
-
-  const { data } = useGetGroupsNames({
-    startWidth: debounceValue,
-    enabled: !!debounceValue,
   });
 
   const setUserState = useSetRecoilState(userState);
@@ -131,7 +117,6 @@ const ProfileSection = ({
         <EditInfo
           newName={newName}
           newGroup={newGroup}
-          groupSearchResult={data}
           onClickDone={handleClickDone}
           onClickClose={() => {
             setNewImage(null);


### PR DESCRIPTION
## 💻 개요

- 리팩토링

- #176 

## 📋 변경 및 추가 사항

- `useGetGroupsNames` 훅을 `EditInfo` 내로 이동시켰습니다.

  - 따라서 해당 훅에서 사용하는 값과 관련된 `useDebounce`도 같이 이사했습니다

  - `EditInfo` 컴포넌트의 불필요한 props를 제거했습니다

|이전|현재|
|:---:|:---:|
|![image](https://github.com/snack-game/front/assets/87255462/5e800749-c896-4a63-a90d-b8304b42b0c1)|![name](https://github.com/snack-game/front/assets/87255462/6be434f1-681a-4935-943a-95b0839850b2)|
|프로필 수정 전에도 검색 쿼리 날아가는 중|수정 버튼 눌러야 날아감|


## 💬 To. 리뷰어

서버 요청은 필요할 때만!!! 하면 되는데 컴포넌트 분리할 때 이 부분에 대한 고민이 부족했던 거 같아요 🤔
좋은 지적 감사감사합니다!!!!!!!!!!!!!