### PR TITLE
feat: 게임 종료 모달에 레벨/경험치 정보 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@vercel/analytics": "^1.1.1",
     "axios": "^1.4.0",
     "chart.js": "^4.4.1",
+    "chartjs-plugin-datalabels": "^2.2.0",
     "framer-motion": "^10.17.0",
     "i18next": "^23.7.8",
     "i18next-browser-languagedetector": "^7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   chart.js:
     specifier: ^4.4.1
     version: 4.4.2
+  chartjs-plugin-datalabels:
+    specifier: ^2.2.0
+    version: 2.2.0(chart.js@4.4.2)
   framer-motion:
     specifier: ^10.17.0
     version: 10.18.0(react-dom@18.2.0)(react@18.2.0)
@@ -5330,6 +5333,14 @@ packages:
     engines: {pnpm: '>=8'}
     dependencies:
       '@kurkle/color': 0.3.2
+    dev: false
+
+  /chartjs-plugin-datalabels@2.2.0(chart.js@4.4.2):
+    resolution: {integrity: sha512-14ZU30lH7n89oq+A4bWaJPnAG8a7ZTk7dKf48YAzMvJjQtjrgg5Dpk9f+LbjCF6bpx3RAGTeL13IXpKQYyRvlw==}
+    peerDependencies:
+      chart.js: '>=3.0.0'
+    dependencies:
+      chart.js: 4.4.2
     dev: false
 
   /check-error@1.0.3:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,8 +94,8 @@ const App = () => {
               }
             />
           </Routes>
+          <Modal />
         </Suspense>
-        <Modal />
         <Toast />
       </ErrorBoundary>
     </>

--- a/src/api/apple-game.api.ts
+++ b/src/api/apple-game.api.ts
@@ -1,5 +1,6 @@
 import {
   checkMoveType,
+  gameEndType,
   goldModeType,
 } from '@pages/games/AppleGame/game/game.type';
 
@@ -39,8 +40,12 @@ const appleGameApi = {
     };
   },
 
-  gameEnd: async (sessionId: number): Promise<void> => {
-    await api.put(`${appleGameApi.endPoint.gameEnd}/${sessionId}/end`);
+  gameEnd: async (sessionId: number): Promise<gameEndType> => {
+    const { data } = await api.put(
+      `${appleGameApi.endPoint.gameEnd}/${sessionId}/end`,
+    );
+
+    return { ...data };
   },
 
   gameRefresh: async (sessionId: number): Promise<goldModeType> => {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -39,7 +39,7 @@ const Modal = () => {
         >
           <motion.div
             className={
-              'absolute left-1/2 top-1/2 h-1/2 w-[80%] rounded-xl bg-white p-10 shadow-md lg:max-h-[600px] lg:w-1/4 lg:max-w-[400px]'
+              'absolute left-1/2 top-1/2 h-1/2 w-[80%] min-w-fit rounded-xl bg-white p-10 shadow-md lg:max-h-[600px] lg:w-1/4 lg:max-w-[400px]'
             }
             onClick={(event) => event.stopPropagation()}
             initial={{ y: 10, opacity: 0, x: '-50%' }}

--- a/src/pages/games/AppleGame/components/ExpBarChart.tsx
+++ b/src/pages/games/AppleGame/components/ExpBarChart.tsx
@@ -1,0 +1,123 @@
+import { Bar } from 'react-chartjs-2';
+
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+} from 'chart.js';
+import ChartDataLabels from 'chartjs-plugin-datalabels';
+
+import { StatusType } from '@utils/types/member.type';
+
+import { TIER_COLOR } from '@constants/tier.constant';
+
+import type { ChartOptions, Plugin } from 'chart.js';
+
+type Align =
+  | 'bottom'
+  | 'center'
+  | 'end'
+  | 'left'
+  | 'right'
+  | 'start'
+  | 'top'
+  | number;
+type Anchor = 'center' | 'end' | 'start';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, ChartDataLabels);
+
+const ExpBarChart = ({ status }: { status: StatusType }) => {
+  const { level, exp, maxExp } = status;
+  const currentRatio = (exp / maxExp) * 100;
+  const tier = Math.floor(level / 10);
+
+  const data = {
+    labels: [''],
+    datasets: [
+      {
+        data: [currentRatio],
+        backgroundColor: TIER_COLOR[tier],
+        barPercentage: 1,
+      },
+    ],
+  };
+
+  const labelPositionOptions: { align: Align; anchor: Anchor } = {
+    align: currentRatio < 40 ? 'end' : 'center',
+    anchor: currentRatio < 40 ? 'end' : 'center',
+  };
+  const options: ChartOptions<'bar'> = {
+    indexAxis: 'y',
+    elements: {
+      bar: {
+        borderWidth: 0,
+        borderSkipped: false,
+        borderRadius: 10,
+      },
+    },
+    scales: {
+      x: {
+        grid: { display: false },
+        ticks: { display: false },
+        border: { display: false },
+        min: 0,
+        max: 100,
+      },
+      y: {
+        grid: { display: false },
+        ticks: { display: true, padding: -4 },
+        border: { display: false },
+      },
+    },
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      title: { display: false },
+      datalabels: {
+        formatter: () => `${currentRatio.toFixed()}%`,
+        display: true,
+        color: 'black',
+        offset: 0,
+        ...labelPositionOptions,
+        font: { family: 'DovemayoGothic', weight: 'normal', size: 16 },
+      },
+    },
+    events: [],
+  };
+
+  const backgroundPlugin: Plugin<'bar'> = {
+    id: 'backgroundPlugin',
+    beforeDatasetsDraw(chart) {
+      const {
+        ctx,
+        chartArea: { left, width, height },
+        scales: { y },
+      } = chart;
+
+      const barThickness = height * 0.8;
+
+      ctx.save();
+      ctx.fillStyle = 'rgba(234, 234, 234)';
+      ctx.roundRect(
+        left,
+        y.getPixelForValue(0) - barThickness / 2,
+        width,
+        barThickness,
+        10,
+      );
+      ctx.fill();
+    },
+  };
+  const plugins = [backgroundPlugin];
+
+  return (
+    <div className="relative h-[50px] w-[300px] font-normal">
+      <Bar data={data} options={options} plugins={plugins} />
+      <p className="absolute bottom-[-15px] left-1">Lv {level}</p>
+      <p className="absolute bottom-[-15px] right-1">Lv {level + 1}</p>
+    </div>
+  );
+};
+
+export default ExpBarChart;

--- a/src/pages/games/AppleGame/components/GameResult.tsx
+++ b/src/pages/games/AppleGame/components/GameResult.tsx
@@ -36,7 +36,7 @@ const GameResult = ({ score, percentile, reStart }: GameResultProps) => {
   return (
     <div className={'flex h-full w-full flex-col justify-evenly'}>
       <div className={'mx-auto flex flex-col items-center gap-4 font-semibold'}>
-        <p>최종점수: {score}점</p>
+        <p className="text-6xl text-primary">{score}점</p>
 
         {userStateValue.type !== 'GUEST' && (
           <>

--- a/src/pages/games/AppleGame/components/GameResult.tsx
+++ b/src/pages/games/AppleGame/components/GameResult.tsx
@@ -4,15 +4,22 @@ import OAuth from '@components/Auth/OAuth';
 import Button from '@components/Button/Button';
 import { userState } from '@utils/atoms/member.atom';
 
-import { useIntegrateMember } from '@hooks/queries/members.query';
+import {
+  useGetMemberProfile,
+  useIntegrateMember,
+} from '@hooks/queries/members.query';
 import useModal from '@hooks/useModal';
+
+import ExpBarChart from './ExpBarChart';
 
 interface GameResultProps {
   score: number;
+  percentile?: number;
   reStart: () => void;
 }
 
-const GameResult = ({ score, reStart }: GameResultProps) => {
+const GameResult = ({ score, percentile, reStart }: GameResultProps) => {
+  const profile = useGetMemberProfile();
   const userStateValue = useRecoilValue(userState);
   const integrateMember = useIntegrateMember();
   const { closeModal } = useModal();
@@ -28,8 +35,16 @@ const GameResult = ({ score, reStart }: GameResultProps) => {
 
   return (
     <div className={'flex h-full w-full flex-col justify-evenly'}>
-      <div className={'mx-auto flex flex-col gap-4 font-semibold'}>
-        <p>최종점수: {score}점!</p>
+      <div className={'mx-auto flex flex-col items-center gap-4 font-semibold'}>
+        <p>최종점수: {score}점</p>
+
+        {userStateValue.type !== 'GUEST' && (
+          <>
+            {percentile && <p>전체 사용자 중 상위 {percentile}%의 점수에요!</p>}
+            {profile.status && <ExpBarChart status={profile.status} />}
+          </>
+        )}
+
         <Button onClick={handleReStartButton} size={'lg'}>
           재시작!
         </Button>

--- a/src/pages/games/AppleGame/game/game.type.ts
+++ b/src/pages/games/AppleGame/game/game.type.ts
@@ -26,3 +26,8 @@ export interface checkMoveType {
   sessionId: number;
   rects: scoredAppleRectType[];
 }
+
+export interface gameEndType {
+  score: number;
+  percentile: number;
+}

--- a/src/pages/games/AppleGame/game/view/appleGame/DefaultMode.tsx
+++ b/src/pages/games/AppleGame/game/view/appleGame/DefaultMode.tsx
@@ -79,13 +79,21 @@ const DefaultMode = () => {
   const endGame = async () => {
     try {
       await checkMoves(sessionId, removedRects);
-      await gameEnd.mutateAsync(sessionId);
+      const { percentile } = await gameEnd.mutateAsync(sessionId);
 
       setAppleGame(emptyGame);
       setIsOngoing(false);
 
       openToast('게임 종료!', 'success');
-      openModal({ children: <GameResult score={score} reStart={startGame} /> });
+      openModal({
+        children: (
+          <GameResult
+            score={score}
+            percentile={percentile}
+            reStart={startGame}
+          />
+        ),
+      });
     } catch (e) {
       setError(new Error('게임 종료에 실패했습니다.'));
     }


### PR DESCRIPTION
## 💻 개요

- 신규 피처

- #153

## 📋 변경 및 추가 사항

- 게임 종료시 모달(`GameResult`)에서 레벨/경험치 정보를 그래프로 보여줍니다.

  - 게스트가 아닌 회원에게만 노출되는 UI입니다

- 화면 너비가 좁고 && 경험치가 낮을 때는 퍼센트 텍스트가 일부 잘리는 현상이 있어 경험치에 따라 텍스트 위치를 다르게 지정해놨습니다
  | 40% 미만 | 40% 이상 |
  |:---:|:---:|
  | <img width="420" alt="anchor_end" src="https://github.com/snack-game/front/assets/87255462/af4ea55a-17aa-4f3a-81d6-d5c7bbfa9637">|<img width="422" alt="anchor_center" src="https://github.com/snack-game/front/assets/87255462/0301c503-fc3e-42a7-b230-a3be61dc4840">|


## 💬 To. 리뷰어

1. 원래 이 부분에서 API 호출이 2번 있어서 (게임 세션 종료, 프로필 정보)
  지연 시간 동안 로딩 UI를 띄워서 처리해보기로 회의때 얘기가 됐었는데요!!
  로딩 UI가 없어도 크게 문제되는 부분이 없어서 일단 그 부분은 제외하고 올렸습니다

2. `GameResult` 내부 내용들 (점수, 레벨, 경험치, 상위 %) 사이 위계 구분이 잘 안되는 거 같아 글자 스타일에 변화를 좀 줘보려고 합니다!! 이 부분은,, 피그마 슬쩍 만져보고 이따 코어 타임에 슬쩍 공유해볼게요 

    <img width="303" alt="text_large" src="https://github.com/snack-game/front/assets/87255462/435e2605-69f3-4c28-92a7-a0e1fd730abf">

