### PR TITLE
fix: `ExpChart` 내 도넛 차트의 datalabels display:false로 지정

### DIFF
--- a/src/pages/user/components/ExpChart.tsx
+++ b/src/pages/user/components/ExpChart.tsx
@@ -1,6 +1,6 @@
 import { Doughnut } from 'react-chartjs-2';
 
-import { Chart as ChartJS, ArcElement } from 'chart.js';
+import { Chart as ChartJS, ArcElement, ChartOptions } from 'chart.js';
 
 import { StatusType } from '@utils/types/member.type';
 
@@ -22,6 +22,14 @@ const ExpChart = ({ status }: { status: StatusType }) => {
     ],
   };
 
+  const options: ChartOptions<'doughnut'> = {
+    plugins: {
+      datalabels: {
+        display: false,
+      },
+    },
+  };
+
   function calculateData() {
     const currentRatio = (exp / maxExp) * 100;
     return [currentRatio, 100 - currentRatio];
@@ -29,7 +37,7 @@ const ExpChart = ({ status }: { status: StatusType }) => {
 
   return (
     <div className="flex h-44 w-44 justify-center">
-      <Doughnut data={data} />
+      <Doughnut data={data} options={options} />
       <div
         className={`absolute bottom-[-16px] z-10 flex h-10 w-10 items-center justify-center rounded-full text-xl text-white drop-shadow`}
         style={{ backgroundColor: TIER_COLOR[tier] }}


### PR DESCRIPTION
## 💻 개요

- 이슈대응

- #182 

## 📋 변경 및 추가 사항

- `ExpChart` 도넛 차트에서 데이터 라벨이 보이지 않도록 display: false를 지정해줬습니다

  흠.................... 차트 많이 썼으면 매번 display:false 지정하기 좀... 번거로웠을 거 같으네요

  지금은 차트 2개만 있으니까 일단 봐주지만....
  
|display 지정 전 (default true)|display 지정 후|
|:---:|:---:|
|![image](https://github.com/snack-game/front/assets/87255462/f410bff0-c5f5-42ea-a447-e6536988e374)|![image](https://github.com/snack-game/front/assets/87255462/f8d1c54f-c0d2-49a5-9db6-cb66b5297b99)|


## 💬 To. 리뷰어

