### PR TITLE
fix: tailwind css className 병합 문제를 tailwind-merge로 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react-i18next": "^13.5.0",
     "react-router-dom": "^6.11.2",
     "recoil": "^0.7.7",
-    "recoil-persist": "^5.1.0"
+    "recoil-persist": "^5.1.0",
+    "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.6.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ dependencies:
   recoil-persist:
     specifier: ^5.1.0
     version: 5.1.0(recoil@0.7.7)
+  tailwind-merge:
+    specifier: ^2.3.0
+    version: 2.3.0
 
 devDependencies:
   '@storybook/addon-essentials':
@@ -1517,6 +1520,13 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
+
+  /@babel/runtime@7.24.4:
+    resolution: {integrity: sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      regenerator-runtime: 0.14.1
+    dev: false
 
   /@babel/template@7.24.0:
     resolution: {integrity: sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==}
@@ -10703,6 +10713,12 @@ packages:
   /synchronous-promise@2.0.17:
     resolution: {integrity: sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==}
     dev: true
+
+  /tailwind-merge@2.3.0:
+    resolution: {integrity: sha512-vkYrLpIP+lgR0tQCG6AP7zZXCTLc1Lnv/CCRT3BqJ9CZ3ui2++GPaGb1x/ILsINIMSYqqvrpqjUFsMNLlW99EA==}
+    dependencies:
+      '@babel/runtime': 7.24.4
+    dev: false
 
   /tailwindcss@3.4.1(ts-node@10.9.2):
     resolution: {integrity: sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==}

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 import { motion } from 'framer-motion';
+import { twMerge } from 'tailwind-merge';
 
 type Size = 'md' | 'lg';
 
@@ -40,9 +41,11 @@ const Button = ({
     <motion.button
       onClick={onClick}
       disabled={disabled}
-      className={`rounded-md disabled:pointer-events-none disabled:opacity-50 
-      ${completeButtonClass}
-      ${className && className}`}
+      className={twMerge(
+        'rounded-md disabled:pointer-events-none disabled:opacity-50',
+        completeButtonClass,
+        className,
+      )}
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
     >

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 
 import { motion } from 'framer-motion';
 import { useRecoilValue, useResetRecoilState } from 'recoil';
+import { twMerge } from 'tailwind-merge';
 
 import authApi from '@api/auth.api';
 import Hamburger from '@assets/icon/hamburger.svg?react';
@@ -53,7 +54,7 @@ const Header = ({ children, className }: HeaderProps) => {
   };
 
   return (
-    <header className={`z-50 w-full bg-white shadow-md ${className}`}>
+    <header className={twMerge('z-50 w-full bg-white shadow-md', className)}>
       <div className="container relative mx-auto flex max-w-7xl flex-col items-center justify-between p-4 lg:flex-row lg:justify-between xl:px-0">
         <div className={'flex w-full items-center justify-between lg:flex-1'}>
           <RouterLink to={'/'} hover={false}>

--- a/src/components/RouterLink/RouterLink.tsx
+++ b/src/components/RouterLink/RouterLink.tsx
@@ -1,6 +1,8 @@
 import { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 
+import { twMerge } from 'tailwind-merge';
+
 interface RouterLinkProps {
   children: ReactNode;
   className?: string;
@@ -18,16 +20,15 @@ const RouterLink = ({
   onClick,
   isActivated = false,
 }: RouterLinkProps) => {
+  const defaultStyle = `flex font-medium underline-offset-4 transition-colors duration-200 ${
+    hover &&
+    'hover:border-b-2 hover:border-b-primary hover:font-bold hover:text-primary'
+  } ${isActivated ? 'text-primary' : 'text-gray-400'}
+  `;
+
   return (
     <Link
-      className={`flex font-medium underline-offset-4 transition-colors duration-200 
-      ${className} 
-      ${
-        hover &&
-        'hover:border-b-2 hover:border-b-primary hover:font-bold hover:text-primary'
-      }
-      ${isActivated ? 'text-primary' : 'text-gray-400'}
-      `}
+      className={twMerge(defaultStyle, className)}
       to={to}
       onClick={onClick}
     >

--- a/src/components/RouterLink/RouterLink.tsx
+++ b/src/components/RouterLink/RouterLink.tsx
@@ -20,7 +20,7 @@ const RouterLink = ({
   onClick,
   isActivated = false,
 }: RouterLinkProps) => {
-  const defaultStyle = `flex font-medium underline-offset-4 transition-colors duration-200 ${
+  const defaultLinkClass = `flex font-medium underline-offset-4 transition-colors duration-200 ${
     hover &&
     'hover:border-b-2 hover:border-b-primary hover:font-bold hover:text-primary'
   } ${isActivated ? 'text-primary' : 'text-gray-400'}
@@ -28,7 +28,7 @@ const RouterLink = ({
 
   return (
     <Link
-      className={twMerge(defaultStyle, className)}
+      className={twMerge(defaultLinkClass, className)}
       to={to}
       onClick={onClick}
     >

--- a/src/pages/user/components/EditInfo.tsx
+++ b/src/pages/user/components/EditInfo.tsx
@@ -1,3 +1,4 @@
+import Button from '@components/Button/Button';
 import Input from '@components/Input/Input';
 import Spacing from '@components/Spacing/Spacing';
 
@@ -66,23 +67,22 @@ const EditInfo = ({
       </div>
 
       <div className={'flex gap-2'}>
-        <button
+        <Button
           onClick={onClickClose}
-          className={
-            'rounded-md border bg-white px-4 py-1 hover:bg-white hover:text-black '
-          }
+          className={'border bg-white hover:bg-white hover:text-black '}
+          style="border"
         >
           닫기
-        </button>
-        <button
+        </Button>
+        <Button
           disabled={!newName.valid || !newGroup.valid}
           onClick={onClickDone}
           className={
-            'rounded-md bg-button-enabled px-4 py-1 text-white disabled:cursor-not-allowed disabled:bg-button-disabled disabled:opacity-100'
+            'bg-button-enabled disabled:bg-button-disabled disabled:opacity-100'
           }
         >
           확인
-        </button>
+        </Button>
       </div>
     </>
   );


### PR DESCRIPTION
## 💻 개요

- 이슈 대응
- #138 

## 📋 변경 및 추가 사항

- props로 className을 받는 공통 컴포넌트에 `twMerge`를 사용하도록 수정했습니다.

  (이제 확인 버튼 초록색으로 잘 뜸)

  ![button](https://github.com/snack-game/front/assets/87255462/ae05601f-0f52-401a-84f8-65c59b93dfd6)


## 💬 To. 리뷰어

`RouterLink`의 기본 style이 꽤 복잡해서, `defaultStyle`이라는 변수로 뺐는데 이럴거면 아예 하나하나 다 쪼개는 게 나을까요?
```ts
// 현재
 const defaultStyle = `flex font-medium underline-offset-4 transition-colors duration-200 ${
    hover &&
    'hover:border-b-2 hover:border-b-primary hover:font-bold hover:text-primary'
  } ${isActivated ? 'text-primary' : 'text-gray-400'}
  `;

// 조각조각 땃땃따
const defaultStyle = `flex font-medium underline-offset-4 transition-colors duration-200`
const hoverStyle = `${hover && 'hover:border-b-2 hover:border-b-primary hover:font-bold hover:text-primary'}`
const textStyle = `${isActivated ? 'text-primary' : 'text-gray-400'}`;
```
