### PR TITLE
Feat: 시즌 정보를 서버에서 받아오기

### DIFF
--- a/src/api/ranking.api.ts
+++ b/src/api/ranking.api.ts
@@ -1,5 +1,5 @@
 import api from '@api/index';
-import { RankingType } from '@utils/types/common.type';
+import { RankingType, SeasonType } from '@utils/types/common.type';
 
 const rankingApi = {
   endPoint: {
@@ -8,6 +8,8 @@ const rankingApi = {
 
     seasonRanking: '/rankings',
     seasonRankingMe: '/rankings',
+
+    seasons: '/seasons',
   },
 
   headers: {
@@ -36,6 +38,11 @@ const rankingApi = {
     const { data } = await api.get(
       `${rankingApi.endPoint.seasonRankingMe}/${season}/me?by=BEST_SCORE`,
     );
+    return data;
+  },
+
+  seasons: async (): Promise<SeasonType[]> => {
+    const { data } = await api.get(rankingApi.endPoint.seasons);
     return data;
   },
 };

--- a/src/constants/api.constant.ts
+++ b/src/constants/api.constant.ts
@@ -8,6 +8,7 @@ export const QUERY_KEY = {
 
   SEASON_RANKING: 'seasonRanking',
   SEASON_USER_RANKING: 'seasonUserRanking',
+  SEASONS: 'seasons',
 
   GAME_HISTORY: 'gameHistory',
 };

--- a/src/hooks/queries/ranking.query.ts
+++ b/src/hooks/queries/ranking.query.ts
@@ -2,7 +2,7 @@ import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import rankingApi from '@api/ranking.api';
-import { RankingType } from '@utils/types/common.type';
+import { RankingType, SeasonType } from '@utils/types/common.type';
 
 import { QUERY_KEY, ServerError } from '@constants/api.constant';
 
@@ -47,6 +47,16 @@ export const useGetSeasonRankingMe = (season: number) => {
 
       return error.response?.status >= 500;
     },
+  });
+
+  return data;
+};
+
+export const useGetSeasons = () => {
+  const { data } = useSuspenseQuery<SeasonType[], AxiosError<ServerError>>({
+    queryKey: [QUERY_KEY.SEASONS],
+    queryFn: () => rankingApi.seasons(),
+    staleTime: 1000 * 60 * 60 * 24 * 30,
   });
 
   return data;

--- a/src/pages/games/SnackGame/ranking/RankingPage.tsx
+++ b/src/pages/games/SnackGame/ranking/RankingPage.tsx
@@ -17,12 +17,10 @@ const RankingPage = () => {
       name: '전체',
       onClick: () => setSelectedSeason(0),
     },
-    ...seasonData.map((season) => {
-      return {
-        name: season.name,
-        onClick: () => setSelectedSeason(season.id),
-      };
-    }),
+    ...seasonData.map((season) => ({
+      name: season.name,
+      onClick: () => setSelectedSeason(season.id),
+    })),
   ];
 
   const [selectedSeason, setSelectedSeason] = useState<number>(latestSeason);

--- a/src/pages/games/SnackGame/ranking/RankingPage.tsx
+++ b/src/pages/games/SnackGame/ranking/RankingPage.tsx
@@ -2,9 +2,7 @@ import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 
 import Dropdown, { DropDownOptionType } from '@components/DropDown/DropDown';
-import Footer from '@components/Footer/Footer';
 import Spacing from '@components/Spacing/Spacing';
-import AppleGameHeader from '@pages/games/SnackGame/components/AppleGameHeader';
 import RankingSection from '@pages/games/SnackGame/ranking/components/RankingSection';
 
 import { useGetSeasons } from '@hooks/queries/ranking.query';

--- a/src/pages/games/SnackGame/ranking/RankingPage.tsx
+++ b/src/pages/games/SnackGame/ranking/RankingPage.tsx
@@ -31,7 +31,6 @@ const RankingPage = () => {
         <title>Snack Game || Ranking</title>
       </Helmet>
 
-      <AppleGameHeader />
       <Spacing size={2} />
       <div className="mx-auto w-[90%] max-w-4xl">
         <Dropdown
@@ -42,7 +41,6 @@ const RankingPage = () => {
       </div>
       <Spacing size={8} />
       <RankingSection season={selectedSeason} />
-      <Footer />
     </>
   );
 };

--- a/src/pages/games/SnackGame/ranking/RankingPage.tsx
+++ b/src/pages/games/SnackGame/ranking/RankingPage.tsx
@@ -7,19 +7,25 @@ import Spacing from '@components/Spacing/Spacing';
 import AppleGameHeader from '@pages/games/SnackGame/components/AppleGameHeader';
 import RankingSection from '@pages/games/SnackGame/ranking/components/RankingSection';
 
-const RankingPage = () => {
-  const [selectedSeason, setSelectedSeason] = useState<number>(1);
+import { useGetSeasons } from '@hooks/queries/ranking.query';
 
+const RankingPage = () => {
+  const seasonData = useGetSeasons();
+  const latestSeason = seasonData.slice(-1)[0].id;
   const dropdownOptions: DropDownOptionType[] = [
     {
       name: '전체',
       onClick: () => setSelectedSeason(0),
     },
-    {
-      name: '시즌 1',
-      onClick: () => setSelectedSeason(1),
-    },
+    ...seasonData.map((season) => {
+      return {
+        name: season.name,
+        onClick: () => setSelectedSeason(season.id),
+      };
+    }),
   ];
+
+  const [selectedSeason, setSelectedSeason] = useState<number>(latestSeason);
 
   return (
     <>
@@ -31,7 +37,7 @@ const RankingPage = () => {
       <Spacing size={2} />
       <div className="mx-auto w-[90%] max-w-4xl">
         <Dropdown
-          initialOption={1}
+          initialOption={latestSeason}
           options={dropdownOptions}
           className="max-w-[120px]"
         />

--- a/src/pages/games/SnackGame/ranking/RankingPage.tsx
+++ b/src/pages/games/SnackGame/ranking/RankingPage.tsx
@@ -11,7 +11,7 @@ import { useGetSeasons } from '@hooks/queries/ranking.query';
 
 const RankingPage = () => {
   const seasonData = useGetSeasons();
-  const latestSeason = seasonData.slice(-1)[0].id;
+  const latestSeason = seasonData[seasonData.length - 1].id;
   const dropdownOptions: DropDownOptionType[] = [
     {
       name: '전체',

--- a/src/pages/games/SnackGame/ranking/components/UserRanking.tsx
+++ b/src/pages/games/SnackGame/ranking/components/UserRanking.tsx
@@ -21,7 +21,7 @@ const UserRanking = ({ season }: UserRankingProps) => {
   return (
     <>
       {userRanking && (
-        <div className="fixed bottom-5 left-1/2 w-[90%] -translate-x-1/2 rounded-full border-2 border-primary bg-primary-light px-6 py-3 text-primary-deep-dark lg:w-1/3">
+        <div className="fixed bottom-20 left-1/2 w-[90%] -translate-x-1/2 rounded-full border-2 border-primary bg-primary-light px-6 py-3 text-primary-deep-dark lg:w-1/3">
           <div className="flex h-full w-full items-center justify-around">
             <div className="flex flex-col">
               <div className="text-xs">{userRanking?.owner.group?.name}</div>

--- a/src/utils/types/common.type.ts
+++ b/src/utils/types/common.type.ts
@@ -37,6 +37,13 @@ export type RankingType = {
   message?: string;
 };
 
+export type SeasonType = {
+  id: number;
+  name: string;
+  startedAt: string;
+  endedAt: string | null;
+};
+
 export type MouseEventType = React.MouseEvent<HTMLCanvasElement> | TouchEvent;
 
 export interface canvasOffsetType {


### PR DESCRIPTION
## 💻 개요

- 리팩토링
- #202 

## 📋 변경 및 추가 사항

- 시즌 정보를 서버에서 받아와서 띄우는 방식으로 수정했습니다

  - 진행 중인 시즌은 endedAt 필드가 null이어서 `SeasonType.endedAt: string | null` 입니다!
  - 시즌 정보는 매번 새로 받아올 필요가 없다고 생각해서 (자주 안 바뀌니까) staleTime을 30일로 넣어봤습니다

    ![ranking](https://github.com/snack-game/front/assets/87255462/8c66f4ce-502c-46df-a0a6-1826b6c97b05)

- `UserRanking` bottom 값을 수정했습니다

  - `BottomNav`랑 겹쳐서 보이고 있어서 살짝 올렸어요!!

    ![image](https://github.com/snack-game/front/assets/87255462/b12150e3-099d-4df5-be61-572f21ae1e9a)


## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
