### PR TITLE
Feat: 타이머, 스코어 위치 및 애니메이션 교체

### DIFF
--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -81,7 +81,7 @@ export class GameScreen extends Container {
   /** 스낵이 제거될 때 트리거 됩니다. */
   private onPop(data: SnackGameOnPopData) {
     this.vfx?.onPop(data);
-    this.timer.upWavesPosition();
+    this.score.upWavesPosition();
   }
 
   /** 게임을 일시 정지 합니다. */
@@ -112,12 +112,12 @@ export class GameScreen extends Container {
     this.gameContainer.pivot = 0;
 
     this.timer.x = centerX;
-    this.timer.y = div - 80;
-    this.timer.width = width * 0.3;
-    this.timer.height = height * 0.1;
+    this.timer.y = 10;
 
+    this.score.width = width * 0.3;
+    this.score.height = height * 0.1;
     this.score.x = centerX;
-    this.score.y = 10;
+    this.score.y = div - 80;
 
     this.beforGameStart.x = centerX;
     this.beforGameStart.y = centerY;

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -130,7 +130,7 @@ export class GameScreen extends Container {
     this.timer.show();
     await this.beforGameStart.show();
     await waitFor(0.3);
-    this.vfx?.playPopExplosion({ x: this.timer.x, y: this.timer.y });
+    this.vfx?.playPopExplosion({ x: this.score.x, y: this.score.y });
     for (const snack of this.snackGame.board.snacks) {
       this.vfx?.animationBeforStart(snack);
     }

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -58,7 +58,6 @@ export class GameScreen extends Container {
     const snackGameConfig = snackGameGetConfig({
       rows: 8,
       columns: 6,
-      tileSize: 55,
       duration: 120,
       mode: getUrlParam('mode') as SnackGameMode,
     });
@@ -109,11 +108,11 @@ export class GameScreen extends Container {
     const centerY = height * 0.5;
 
     this.gameContainer.x = centerX;
-    this.gameContainer.y = div + this.snackGame.board.getHeight() * 0.5 + 20;
+    this.gameContainer.y = div + this.snackGame.board.getHeight() * 0.5;
     this.gameContainer.pivot = 0;
 
     this.timer.x = centerX;
-    this.timer.y = div - 100;
+    this.timer.y = div - 80;
     this.timer.width = width * 0.3;
     this.timer.height = height * 0.1;
 

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameBoard.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameBoard.ts
@@ -60,7 +60,6 @@ export class SnackGameBoard {
     this.rows = config.rows;
     this.columns = config.columns;
     this.tileSize = 50;
-    console.log(this.tileSize);
     this.snacksMask.width = this.getWidth();
     this.snacksMask.height = this.getHeight();
     this.snacksContainer.visible = true;

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameBoard.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameBoard.ts
@@ -59,7 +59,8 @@ export class SnackGameBoard {
   public setup(config: SnackGameConfig) {
     this.rows = config.rows;
     this.columns = config.columns;
-    this.tileSize = config.tileSize;
+    this.tileSize = 50;
+    console.log(this.tileSize);
     this.snacksMask.width = this.getWidth();
     this.snacksMask.height = this.getHeight();
     this.snacksContainer.visible = true;
@@ -114,7 +115,6 @@ export class SnackGameBoard {
     snack.setup({
       name,
       type: snackType,
-      size: this.snackGame.config.tileSize,
       interactive: true,
       snackNum: Math.floor(Math.random() * 9) + 1,
     });

--- a/src/pages/games/SnackGame/game/ui/GameEffect.ts
+++ b/src/pages/games/SnackGame/game/ui/GameEffect.ts
@@ -60,8 +60,8 @@ export class GameEffects extends Container {
     const position = this.toLocal(data.snack.getGlobalPosition());
     this.playPopExplosion(position);
 
-    const x = this.game.timer.x + randomRange(-20, 20);
-    const y = this.game.timer.y - 55;
+    const x = this.game.score.x + randomRange(-20, 20);
+    const y = this.game.score.y - 55;
 
     const snack = pool.get(Snack);
     snack.setup({
@@ -92,8 +92,8 @@ export class GameEffects extends Container {
       interactive: false,
     });
     copySnack.visible = true;
-    copySnack.position.x = this.game.timer.x;
-    copySnack.position.y = this.game.timer.y;
+    copySnack.position.x = this.game.score.x;
+    copySnack.position.y = this.game.score.y;
     this.addChild(copySnack);
     await this.playFlyToTarget(copySnack, { x: position.x, y: position.y });
     snack.visible = true;

--- a/src/pages/games/SnackGame/game/ui/PopExplosion.ts
+++ b/src/pages/games/SnackGame/game/ui/PopExplosion.ts
@@ -17,6 +17,7 @@ export class PopExplosion extends Container {
       const particle = Sprite.from('circle');
       particle.anchor.set(0.5);
       particle.visible = false;
+
       this.particles.push(particle);
       this.addChild(particle);
     }

--- a/src/pages/games/SnackGame/game/ui/Score.ts
+++ b/src/pages/games/SnackGame/game/ui/Score.ts
@@ -73,7 +73,6 @@ export class Score extends Container {
 
   /** waves 컴포넌트의 포지션 y값을 조금씩 뺍니다. */
   public async upWavesPosition() {
-    console.log(this.waves.y);
     gsap.to(this.waves, {
       y: this.waves.y - 1,
       duration: 1,

--- a/src/pages/games/SnackGame/game/ui/Score.ts
+++ b/src/pages/games/SnackGame/game/ui/Score.ts
@@ -38,7 +38,7 @@ export class Score extends Container {
 
     this.circle = new Graphics();
     this.circle.circle(0, 0, app.renderer.height * 0.06);
-    this.circle.fill(0xffffff);
+    this.circle.fill(0xfff7ec);
     this.addChild(this.circle);
 
     this.container = new Container();

--- a/src/pages/games/SnackGame/game/ui/Score.ts
+++ b/src/pages/games/SnackGame/game/ui/Score.ts
@@ -1,16 +1,16 @@
 import gsap from 'gsap';
-import { Container } from 'pixi.js';
+import { Container, Graphics } from 'pixi.js';
 
 import { Cloud } from './Cloud';
 import { Label } from './Label';
+import { Waves } from './Waves';
+import { app } from '../SnackGameBase';
 /**
  * 게임 플레이 동안 표시되는 게임 점수입니다.
  */
 export class Score extends Container {
   /** 애니메이션을 위한 내부 컨테이너 */
   private container: Container;
-  /** 애니메이션된 구름 배경 */
-  private cloud: Cloud;
   /** 표시되는 점수 숫자 */
   private messageLabel: Label;
   /** 현재 설정된 점수 */
@@ -19,31 +19,66 @@ export class Score extends Container {
   private showing = true;
   /** 실제 점수에 도달할 때까지 점진적으로 증가하는 점수 */
   private animatedPoints = 0;
+  /** 파도 효과 */
+  private readonly waves: Waves;
+  /** 애니메이션 컨테이너 원형 마스크 */
+  private readonly background: Graphics;
+  /** 배경 색상을 위한 그래픽 컴포넌트 */
+  private readonly circle: Graphics;
   /** 점수가 업데이트될 때마다 증가하는 빈도수에 따라 sfx 재생 피치 변경 */
   private intensity = 0;
 
   constructor() {
     super();
 
+    this.background = new Graphics();
+    this.background.circle(0, 0, app.renderer.height * 0.06);
+    this.background.fill(0xfff7ec);
+    this.addChild(this.background);
+
+    this.circle = new Graphics();
+    this.circle.circle(0, 0, app.renderer.height * 0.06);
+    this.circle.fill(0xffffff);
+    this.addChild(this.circle);
+
     this.container = new Container();
+    this.container.mask = this.circle;
     this.addChild(this.container);
 
-    this.cloud = new Cloud({
-      color: 0xfff7ec,
-      width: 200,
-      height: 20,
-      circleSize: 50,
-    });
-    this.container.addChild(this.cloud);
+    this.waves = new Waves([0xea4141, 0xff7979]);
+    this.waves.x = -100;
+    this.container.addChild(this.waves);
 
     this.messageLabel = new Label('0', {
       fill: 0xfb923c,
       fontSize: 30,
       fontFamily: 'DovemayoGothic',
     });
-    this.messageLabel.y = 8;
     this.container.addChild(this.messageLabel);
+
     this.points = 0;
+  }
+
+  // waves width 설정
+  public set width(value: number) {
+    this.waves.width = value;
+    this.waves.x = -value / 2;
+    this.waves.y = 40;
+  }
+
+  // waves hegith 설정
+  public set height(value: number) {
+    this.waves.height = value * 2;
+  }
+
+  /** waves 컴포넌트의 포지션 y값을 조금씩 뺍니다. */
+  public async upWavesPosition() {
+    console.log(this.waves.y);
+    gsap.to(this.waves, {
+      y: this.waves.y - 1,
+      duration: 1,
+      ease: 'back.in',
+    });
   }
 
   /** 점수를 0으로 리셋합니다 */

--- a/src/pages/games/SnackGame/game/ui/Timer.ts
+++ b/src/pages/games/SnackGame/game/ui/Timer.ts
@@ -1,76 +1,43 @@
 import gsap from 'gsap';
 import { Container, Graphics } from 'pixi.js';
 
+import { Cloud } from './Cloud';
 import { Label } from './Label';
-import { Waves } from './Waves';
-import { app } from '../SnackGameBase';
 
 /**
  * 게임 플레이 중에 표시되는 게임 타이머, 남은 시간이 10초 미만일 때 빨간색으로 깜빡이기 시작함.
  */
 export class Timer extends Container {
+  /** 애니메이션된 구름 배경 */
+  private cloud: Cloud;
   /** 애니메이션을 위한 컴포넌트 컨테이너 */
   private readonly container: Container;
   /** 표시되는 남은 시간 */
   private readonly messageLabel: Label;
-  /** 파도 효과 */
-  private readonly waves: Waves;
-  /** 애니메이션 컨테이너 원형 마스크 */
-  private readonly circle: Graphics;
-  /** 배경 색상을 위한 그래픽 컴포넌트 */
-  private readonly background: Graphics;
   /** 숨김시 false */
   private showing = true;
 
   constructor() {
     super();
 
-    this.background = new Graphics();
-    this.background.circle(0, 0, app.renderer.height * 0.06);
-    this.background.fill(0xfff7ec);
-    this.addChild(this.background);
-
-    this.circle = new Graphics();
-    this.circle.circle(0, 0, app.renderer.height * 0.06);
-    this.circle.fill(0xffffff);
-    this.addChild(this.circle);
-
     this.container = new Container();
-    this.container.mask = this.circle;
     this.addChild(this.container);
 
-    this.waves = new Waves([0xea4141, 0xff7979]);
-    this.waves.x = -100;
-    this.container.addChild(this.waves);
+    this.cloud = new Cloud({
+      color: 0xfff7ec,
+      width: 200,
+      height: 20,
+      circleSize: 50,
+    });
+    this.container.addChild(this.cloud);
 
     this.messageLabel = new Label('5:00', {
       fontSize: 32,
       fontFamily: 'DovemayoGothic',
       fill: 0xfb923c,
     });
+    this.messageLabel.y = 8;
     this.container.addChild(this.messageLabel);
-  }
-
-  // waves width 설정
-  public set width(value: number) {
-    this.waves.width = value;
-    this.waves.x = -value / 2;
-    this.waves.y = 50;
-  }
-
-  // waves hegith 설정
-  public set height(value: number) {
-    this.waves.height = value * 2;
-  }
-
-  /** waves 컴포넌트의 포지션 y값을 조금씩 뺍니다. */
-  public async upWavesPosition() {
-    if (this.waves.y < -50) return;
-    gsap.to(this.waves, {
-      y: this.waves.y - 1,
-      duration: 1,
-      ease: 'back.in',
-    });
   }
 
   /**

--- a/src/pages/games/SnackGame/game/ui/Timer.ts
+++ b/src/pages/games/SnackGame/game/ui/Timer.ts
@@ -3,6 +3,7 @@ import { Container, Graphics } from 'pixi.js';
 
 import { Label } from './Label';
 import { Waves } from './Waves';
+import { app } from '../SnackGameBase';
 
 /**
  * 게임 플레이 중에 표시되는 게임 타이머, 남은 시간이 10초 미만일 때 빨간색으로 깜빡이기 시작함.
@@ -25,12 +26,12 @@ export class Timer extends Container {
     super();
 
     this.background = new Graphics();
-    this.background.circle(0, 0, 50);
+    this.background.circle(0, 0, app.renderer.height * 0.06);
     this.background.fill(0xfff7ec);
     this.addChild(this.background);
 
     this.circle = new Graphics();
-    this.circle.circle(0, 0, 50);
+    this.circle.circle(0, 0, app.renderer.height * 0.06);
     this.circle.fill(0xffffff);
     this.addChild(this.circle);
 


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 신규 피처
- #219 
- #217 

## 📋 변경 및 추가 사항
# 타이머와 스코어의 위치 및 애니메이션이 교체 되었습니다.
> 점수통에 시간이 들어있어서 왜 차는건지 이해하기 어려움 또, 점수통이 꽉차는 기준이 없어서 얼마나 깨야 점수통이 차는건지 이해하기 어려움
이런 문제가 있어서 좀 더 UI요소의 역할을 명확히 하고자 위치 및 애니메이션을 교체했습니다.

이에 따라 스낵이 날아가는 위치도 변경되었습니다.
![Untitled](https://github.com/snack-game/front/assets/16986867/52a1ad3e-60b3-4254-a32e-f029dd9e7c60)
![스크린샷 2024-05-25 15 57 09](https://github.com/snack-game/front/assets/16986867/36ff22fb-f151-4e19-92bf-7700f5bb4ef5)


## 💬 To. 리뷰어
# Game Layout에 관해서 
현재 화면 높이가 부족한 경우 footer에 SnackGameBoard가 가려지는 문제가 있는데요.
![스크린샷 2024-05-25 16 22 51](https://github.com/snack-game/front/assets/16986867/cc475aeb-94e2-4495-bac5-f20650b04476)
높이에 따라 tilesize를 반응형으로 설정을 해봤었는데요 (기존 50에서 높이에 따라 최하 45까지) 
이런 경우에 생각보다 너무 작아서 불편함이 있더라구요 
사실 footer만 없으면 작은 화면에서도 문제없이 보이게 될거라 추후 footer가 개편되면 알아서 해결될 문제같다고 생각해요.

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
