### PR TITLE
Refactor: 시즌에 등록된 랭킹이 없을 때 빈 페이지 처리

### DIFF
--- a/public/locale/en/ranking.json
+++ b/public/locale/en/ranking.json
@@ -7,5 +7,7 @@
 
   "name_column": "Name",
   "score_column": "Score",
-  "group": "Group"
+  "group": "Group",
+
+  "empty": "The ranking is empty.\nPlay now and become number one!"
 }

--- a/public/locale/ko/ranking.json
+++ b/public/locale/ko/ranking.json
@@ -7,5 +7,7 @@
 
   "name_column": "이름",
   "score_column": "점수",
-  "group": "그룹"
+  "group": "그룹",
+
+  "empty": "랭킹이 비어있어요.\n지금 바로 플레이하고 1등에 올라보세요!"
 }

--- a/src/components/DropDown/DropDown.tsx
+++ b/src/components/DropDown/DropDown.tsx
@@ -45,7 +45,7 @@ export default function Dropdown({
         </motion.div>
       </div>
       {isOpen && (
-        <div className="absolute mt-1 min-w-[150px] divide-y-2 rounded-md border-2 border-primary bg-white">
+        <div className="absolute z-10 mt-1 min-w-[150px] divide-y-2 rounded-md border-2 border-primary bg-white">
           {options.map((option) => (
             <motion.div
               key={option.name}

--- a/src/pages/games/SnackGame/ranking/RankingPage.tsx
+++ b/src/pages/games/SnackGame/ranking/RankingPage.tsx
@@ -43,7 +43,7 @@ const RankingPage = () => {
           className="max-w-[120px]"
         />
       </div>
-      <Spacing size={8} />
+      <Spacing size={6} />
       <RankingSection season={selectedSeason} />
     </>
   );

--- a/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
+++ b/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 import { useRecoilValue } from 'recoil';
 
 import LogoImage from '@assets/images/main.png';
@@ -43,12 +45,14 @@ const RankingSection = ({ season }: RankingSectionProps) => {
 };
 
 const EmptyRanking = () => {
+  const { t } = useTranslation('ranking');
+
   return (
     <div className="flex flex-col items-center justify-center">
       {/* TODO: 이미지 교체 */}
       <img src={LogoImage} />
-      <p className="text-primary-deep-dark">
-        지금 바로 플레이하고 1등에 올라보세요!
+      <p className="whitespace-pre-line text-center text-primary-deep-dark">
+        {t('empty')}
       </p>
     </div>
   );

--- a/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
+++ b/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
@@ -1,5 +1,6 @@
 import { useRecoilValue } from 'recoil';
 
+import LogoImage from '@assets/images/main.png';
 import OtherRanking from '@pages/games/SnackGame/ranking/components/OtherRanking';
 import TopRanking from '@pages/games/SnackGame/ranking/components/TopRanking';
 import { userState } from '@utils/atoms/member.atom';
@@ -29,6 +30,7 @@ const RankingSection = ({ season }: RankingSectionProps) => {
   const topRanking = totalRanking?.slice(0, 3);
   const otherRanking = totalRanking?.slice(3);
 
+  if (totalRanking.length === 0) return <EmptyRanking />;
   return (
     <div className={'mx-auto w-full max-w-4xl'}>
       {topRanking && <TopRanking topRanking={topRanking} />}
@@ -36,6 +38,18 @@ const RankingSection = ({ season }: RankingSectionProps) => {
       {userInfo.type && userInfo.type !== 'GUEST' && (
         <UserRanking season={season} />
       )}
+    </div>
+  );
+};
+
+const EmptyRanking = () => {
+  return (
+    <div className="flex flex-col items-center justify-center">
+      {/* TODO: 이미지 교체 */}
+      <img src={LogoImage} />
+      <p className="text-primary-deep-dark">
+        지금 바로 플레이하고 1등에 올라보세요!
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## 💻 개요

- 리팩토링
- #226

## 📋 변경 및 추가 사항

- `totalRanking`이 빈 배열일 때 보여줄 `EmptyRanking`을 만들었습니다

  - 이거 스낵이가 트로피를 잡고있는 이미지를 넣고 싶어서 일단 TODO로 이미지 교체 주석을 달아두긴 했는데요................
  씁......... 지피티가 못 만들어 낼까요....?

![ranking](https://github.com/snack-game/front/assets/87255462/7c755cff-42ff-43f6-8625-07b5eaa56bf2)

💥이미지가 예전 main.png (과자봉지) 로 뜨긴 하는데 제가 #225 에서 main.png를 스낵이로 바꿔놨어요! 

## 💬 To. 리뷰어

