### PR TITLE
Feat: SnackGame API 연동 및 에러 핸들링 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,7 +102,7 @@ const App = () => {
             <Route
               path={PATH.NOT_FOUND_ERROR}
               element={
-                <ErrorPage code={404} message={'존재하지 않는 페이지입니다!'} />
+                <ErrorPage error={new Error('존재하지 않는 페이지입니다!')} />
               }
             />
           </Routes>

--- a/src/api/apple-game.api.ts
+++ b/src/api/apple-game.api.ts
@@ -1,8 +1,8 @@
 import {
+  goldModeType,
   checkMoveType,
   gameEndType,
-  goldModeType,
-} from '@pages/games/SnackGame/game/game.type';
+} from '@pages/games/SnackGame/game/legacy/legacyType';
 
 import api from './index';
 

--- a/src/components/Error/RetryError.tsx
+++ b/src/components/Error/RetryError.tsx
@@ -2,13 +2,14 @@ import ErrorImage from '@assets/images/error.png';
 import { FallbackProps } from '@components/base/ErrorBoundary';
 import Button from '@components/Button/Button';
 
-const RetryError = ({ message, resetErrorBoundary }: FallbackProps) => {
+const RetryError = ({ error, resetErrorBoundary }: FallbackProps) => {
   return (
     <div className="flex flex-col items-center gap-6 p-4">
       <img className="m-auto h-20 w-20" src={ErrorImage} alt={'에러 이미지'} />
-      <span>{message}</span>
+      <span>{error ? `[${error.code}]: ${error.message}` : ''}</span>
       <Button onClick={resetErrorBoundary}>재시도</Button>
     </div>
   );
 };
+
 export default RetryError;

--- a/src/components/base/ErrorBoundary.tsx
+++ b/src/components/base/ErrorBoundary.tsx
@@ -3,7 +3,7 @@ import { Component, ComponentType, PropsWithChildren } from 'react';
 import * as Sentry from '@sentry/react';
 
 export interface FallbackProps {
-  error?: Error;
+  error?: Error & { code?: string };
   resetErrorBoundary?: () => void;
   message?: string;
 }
@@ -14,7 +14,7 @@ interface ErrorBoundaryProps {
 }
 
 interface ErrorBoundaryState {
-  error: Error | null;
+  error: (Error & { code?: string }) | null;
   message?: string;
 }
 
@@ -36,7 +36,9 @@ class ErrorBoundary extends Component<
   };
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    return { error };
+    const errorWithCode = error as Error & { code?: string };
+    errorWithCode.code = errorWithCode.code || 'UNKNOWN_ERROR';
+    return { error: errorWithCode };
   }
 
   componentDidCatch(error: Error): void {

--- a/src/hooks/queries/appleGame.query.ts
+++ b/src/hooks/queries/appleGame.query.ts
@@ -3,7 +3,7 @@ import { AxiosError } from 'axios';
 import { useRecoilValue } from 'recoil';
 
 import appleGameApi from '@api/apple-game.api';
-import { scoredAppleRectType } from '@pages/games/SnackGame/game/game.type';
+import { scoredAppleRectType } from '@pages/games/SnackGame/game/legacy/legacyType';
 import { userState } from '@utils/atoms/member.atom';
 
 import { ServerError } from '@constants/api.constant';

--- a/src/pages/error/ErrorPage.tsx
+++ b/src/pages/error/ErrorPage.tsx
@@ -8,15 +8,7 @@ import SnackRainContainer from '@components/SnackRain/SnackRainContainer';
 
 import PATH from '@constants/path.constant';
 
-interface ErrorPageProps {
-  code?: number | string;
-  message?: string;
-}
-
-const ErrorPage = ({
-  code = 'Error',
-  message = '오류가 발생했습니다.',
-}: FallbackProps & ErrorPageProps) => {
+const ErrorPage = ({ error }: FallbackProps) => {
   return (
     <>
       <Helmet>
@@ -24,13 +16,9 @@ const ErrorPage = ({
       </Helmet>
       <SnackRainContainer />
 
-      <div className='flex flex-col items-center gap-6'>
-        <img
-          className='m-auto w-20 h-20'
-          src={ErrorImage}
-          alt={'에러 이미지'}
-        />
-        <span>{message}</span>
+      <div className="flex h-screen w-screen flex-col items-center justify-center gap-6">
+        <img className="h-20 w-20" src={ErrorImage} alt={'에러 이미지'} />
+        <span>{error ? `[${error.code}: ${error.message}` : ''}</span>
         <Link to={PATH.MAIN}>
           <Button>돌아가기</Button>
         </Link>

--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -1,14 +1,40 @@
-import { memo, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 
-import { Application } from 'pixi.js';
+import { Application, EventEmitter } from 'pixi.js';
+
+import { toastStateType } from '@utils/types/common.type';
+
+import useError from '@hooks/useError';
+import useToast from '@hooks/useToast';
 
 import usePixiCanvas from './hook/usePixiCanvas';
 
 export const app = new Application();
+export const eventEmitter = new EventEmitter();
 
 const SnackGameBase = () => {
   const canvasBaseRef = useRef<HTMLDivElement>(null);
+  const openToast = useToast();
+  const setError = useError();
   usePixiCanvas({ canvasBaseRef });
+
+  useEffect(() => {
+    const handleToastEvent = (data: toastStateType) => {
+      openToast(data.message, data.type);
+    };
+
+    const handleErrorEvent = (error: Error) => {
+      setError(error);
+    };
+
+    eventEmitter.on('openToast', handleToastEvent);
+    eventEmitter.on('error', handleErrorEvent);
+
+    return () => {
+      eventEmitter.off('openToast', handleToastEvent);
+      eventEmitter.off('error', handleErrorEvent);
+    };
+  }, []);
 
   return (
     <div ref={canvasBaseRef} className={'mx-auto h-full w-full max-w-xl'}></div>

--- a/src/pages/games/SnackGame/game/SnackGamePage.tsx
+++ b/src/pages/games/SnackGame/game/SnackGamePage.tsx
@@ -1,11 +1,24 @@
 import { Helmet } from 'react-helmet-async';
 
+import { useRecoilValue } from 'recoil';
+
 import ErrorBoundary from '@components/base/ErrorBoundary';
 import retryError from '@components/Error/RetryError';
+import { pixiState } from '@utils/atoms/game.atom';
 
+import { LobbyScreen } from './screen/LobbyScreen';
 import SnackGameBase from './SnackGameBase';
+import { navigation } from './util/navigation';
 
 const SnackGamePage = () => {
+  const pixiValue = useRecoilValue(pixiState);
+
+  const handleRetryGameError = () => {
+    if (pixiValue.assetsInit && pixiValue.pixiInit) {
+      navigation.showScreen(LobbyScreen);
+    }
+  };
+
   return (
     <>
       <Helmet>
@@ -13,7 +26,7 @@ const SnackGamePage = () => {
       </Helmet>
 
       <div className={'h-screen bg-game'}>
-        <ErrorBoundary fallback={retryError}>
+        <ErrorBoundary fallback={retryError} onReset={handleRetryGameError}>
           <SnackGameBase />
         </ErrorBoundary>
       </div>

--- a/src/pages/games/SnackGame/game/game.type.ts
+++ b/src/pages/games/SnackGame/game/game.type.ts
@@ -1,35 +1,24 @@
 export type SnackGameMod = 'default' | 'inf';
 
-export interface goldModAppleType {
-  number: number;
-  golden: boolean;
-}
+export type SnackGameAPIStats = 'IN_PROGRESS' | 'PAUSED' | 'EXPIRED';
 
-export interface classicModAppleType {
-  number: number;
-}
-
-export type AppleData = goldModAppleType | classicModAppleType;
-
-export type coordinatesType = { y: number; x: number };
-
-export interface scoredAppleRectType {
-  topLeft: coordinatesType;
-  bottomRight: coordinatesType;
-}
-
-export interface goldModeType {
-  apples: goldModAppleType[][];
+export interface SnackGameDefalutResponse {
+  metadata: {
+    gameId: number;
+    localizedName: string;
+  };
+  ownerId: number;
   sessionId: number;
+  state: SnackGameAPIStats;
   score: number;
+  createdAt: string;
+  board: string;
 }
 
-export interface checkMoveType {
-  sessionId: number;
-  rects: scoredAppleRectType[];
-}
+export type SnackGameStart = SnackGameDefalutResponse;
 
-export interface gameEndType {
-  score: number;
+export type SnackGamePauese = SnackGameDefalutResponse;
+
+export type SnackGameEnd = SnackGameDefalutResponse & {
   percentile: number;
-}
+};

--- a/src/pages/games/SnackGame/game/legacy/legacyType.ts
+++ b/src/pages/games/SnackGame/game/legacy/legacyType.ts
@@ -1,0 +1,33 @@
+export interface goldModAppleType {
+  number: number;
+  golden: boolean;
+}
+
+export interface classicModAppleType {
+  number: number;
+}
+
+export type AppleData = goldModAppleType | classicModAppleType;
+
+export type coordinatesType = { y: number; x: number };
+
+export interface scoredAppleRectType {
+  topLeft: coordinatesType;
+  bottomRight: coordinatesType;
+}
+
+export interface goldModeType {
+  apples: goldModAppleType[][];
+  sessionId: number;
+  score: number;
+}
+
+export interface checkMoveType {
+  sessionId: number;
+  rects: scoredAppleRectType[];
+}
+
+export interface gameEndType {
+  score: number;
+  percentile: number;
+}

--- a/src/pages/games/SnackGame/game/legacy/view/appleGame/DefaultMode.tsx
+++ b/src/pages/games/SnackGame/game/legacy/view/appleGame/DefaultMode.tsx
@@ -3,15 +3,11 @@ import { useEffect, useState } from 'react';
 import QueryBoundary from '@components/base/QueryBoundary';
 import retryError from '@components/Error/RetryError';
 import GameResult from '@pages/games/SnackGame/game/legacy/components/GameResult';
-import {
-  goldModAppleType,
-  scoredAppleRectType,
-} from '@pages/games/SnackGame/game/game.type';
+import SnackGameHUD from '@pages/games/SnackGame/game/legacy/components/SnackGameHUD';
 import Apple from '@pages/games/SnackGame/game/legacy/model/appleGame/apple';
 import { AppleGame } from '@pages/games/SnackGame/game/legacy/model/appleGame/appleGame';
 import { GoldenApple } from '@pages/games/SnackGame/game/legacy/model/appleGame/goldenApple';
 import PlainApple from '@pages/games/SnackGame/game/legacy/model/appleGame/plainApple';
-import SnackGameHUD from '@pages/games/SnackGame/game/legacy/components/SnackGameHUD';
 
 import {
   useAppleGameRefresh,
@@ -24,6 +20,7 @@ import useModal from '@hooks/useModal';
 import useToast from '@hooks/useToast';
 
 import AppleGameView from './AppleGameView';
+import { scoredAppleRectType, goldModAppleType } from '../../legacyType';
 
 const DefaultMode = () => {
   const setError = useError();

--- a/src/pages/games/SnackGame/game/popup/PausePopup.ts
+++ b/src/pages/games/SnackGame/game/popup/PausePopup.ts
@@ -5,7 +5,7 @@ import { eventEmitter } from '../SnackGameBase';
 import { Label } from '../ui/Label';
 import { LargeButton } from '../ui/LargeButton';
 import { RoundedBox } from '../ui/RoundedBox';
-import { gameResume } from '../util/api';
+import { gamePause, gameResume } from '../util/api';
 import { navigation } from '../util/navigation';
 import { storage } from '../util/storage';
 
@@ -51,7 +51,8 @@ export class PausePopup extends Container {
       const gameStats = storage.getObject('game-stats');
       if (!gameStats) throw new Error('게임 세션을 찾을 수 없습니다.');
 
-      await gameResume(gameStats.sessionId);
+      const data = await gameResume(gameStats.sessionId);
+      storage.setObject('game-stats', { ...data });
       navigation.dismissPopup();
     } catch (error) {
       eventEmitter.emit('error', error);
@@ -77,6 +78,15 @@ export class PausePopup extends Container {
     this.panel.pivot.y = -400;
     gsap.to(this.bg, { alpha: 0.8, duration: 0.2, ease: 'linear' });
     await gsap.to(this.panel.pivot, { y: 0, duration: 0.3, ease: 'back.out' });
+
+    try {
+      const gameStats = storage.getObject('game-stats');
+      if (!gameStats) throw new Error('세션을 찾을 수 없습니다.');
+      const data = await gamePause(gameStats.sessionId);
+      storage.setObject('game-stats', { ...data });
+    } catch (error) {
+      eventEmitter.emit('error', error);
+    }
   }
 
   /** 팝업을 애니메이션과 함께 해제 */

--- a/src/pages/games/SnackGame/game/popup/PausePopup.tsx
+++ b/src/pages/games/SnackGame/game/popup/PausePopup.tsx
@@ -1,10 +1,13 @@
 import gsap from 'gsap';
 import { BlurFilter, Container, Sprite, Texture } from 'pixi.js';
 
+import { eventEmitter } from '../SnackGameBase';
 import { Label } from '../ui/Label';
 import { LargeButton } from '../ui/LargeButton';
 import { RoundedBox } from '../ui/RoundedBox';
+import { gameResume } from '../util/api';
 import { navigation } from '../util/navigation';
+import { storage } from '../util/storage';
 
 /** 게임 플레이가 일시 중지되었을 때 표시되는 팝업 */
 export class PausePopup extends Container {
@@ -39,9 +42,21 @@ export class PausePopup extends Container {
 
     this.doneButton = new LargeButton({ text: '완료' });
     this.doneButton.y = 70;
-    this.doneButton.onPress.connect(() => navigation.dismissPopup());
+    this.doneButton.onPress.connect(this.handleDoneButton);
     this.panel.addChild(this.doneButton);
   }
+
+  public handleDoneButton = async () => {
+    try {
+      const gameStats = storage.getObject('game-stats');
+      if (!gameStats) throw new Error('게임 세션을 찾을 수 없습니다.');
+
+      await gameResume(gameStats.sessionId);
+      navigation.dismissPopup();
+    } catch (error) {
+      eventEmitter.emit('error', error);
+    }
+  };
 
   /** 창 크기가 변경될 때마다 호출되는 팝업 크기 조정 */
   public resize(width: number, height: number) {

--- a/src/pages/games/SnackGame/game/popup/SettingPopup.ts
+++ b/src/pages/games/SnackGame/game/popup/SettingPopup.ts
@@ -9,7 +9,7 @@ import { Label } from '../ui/Label';
 import { LargeButton } from '../ui/LargeButton';
 import { RoundedBox } from '../ui/RoundedBox';
 import { VolumeSlider } from '../ui/VolumeSlider';
-import { gameResume } from '../util/api';
+import { gamePause, gameResume } from '../util/api';
 import { navigation } from '../util/navigation';
 import { storage } from '../util/storage';
 import { userSettings } from '../util/userSetting';
@@ -99,7 +99,7 @@ export class SettingsPopup extends Container {
     try {
       const gameStats = storage.getObject('game-stats');
 
-      if (gameStats.state === 'IN_PROGRESS') {
+      if (gameStats.state === 'PAUSED') {
         const data = await gameResume(gameStats.sessionId);
         storage.setObject('game-stats', { ...data });
       }
@@ -136,6 +136,17 @@ export class SettingsPopup extends Container {
     this.panel.pivot.y = -400;
     gsap.to(this.bg, { alpha: 0.8, duration: 0.2, ease: 'linear' });
     await gsap.to(this.panel.pivot, { y: 0, duration: 0.3, ease: 'back.out' });
+
+    const gameStats = storage.getObject('game-stats');
+
+    if (gameStats.state === 'IN_PROGRESS') {
+      try {
+        const data = await gamePause(gameStats.sessionId);
+        storage.setObject('game-stats', { ...data });
+      } catch (error) {
+        eventEmitter.emit('error', error);
+      }
+    }
   }
 
   /** 팝업을 애니메이션과 함께 해제 */

--- a/src/pages/games/SnackGame/game/popup/SettingPopup.ts
+++ b/src/pages/games/SnackGame/game/popup/SettingPopup.ts
@@ -100,7 +100,8 @@ export class SettingsPopup extends Container {
       const gameStats = storage.getObject('game-stats');
 
       if (gameStats.state === 'IN_PROGRESS') {
-        await gameResume(gameStats.sessionId);
+        const data = await gameResume(gameStats.sessionId);
+        storage.setObject('game-stats', { ...data });
       }
 
       navigation.dismissPopup();

--- a/src/pages/games/SnackGame/game/popup/SettingPopup.ts
+++ b/src/pages/games/SnackGame/game/popup/SettingPopup.ts
@@ -4,11 +4,14 @@ import { BlurFilter, Container, Sprite, Texture } from 'pixi.js';
 
 import { GAMEVERSION } from '@constants/common.constant';
 
-import { VolumeSlider } from './VolumeSlider';
+import { eventEmitter } from '../SnackGameBase';
 import { Label } from '../ui/Label';
 import { LargeButton } from '../ui/LargeButton';
 import { RoundedBox } from '../ui/RoundedBox';
+import { VolumeSlider } from '../ui/VolumeSlider';
+import { gameResume } from '../util/api';
 import { navigation } from '../util/navigation';
+import { storage } from '../util/storage';
 import { userSettings } from '../util/userSetting';
 
 /** 볼륨 설정을 위한 팝업 */
@@ -57,7 +60,7 @@ export class SettingsPopup extends Container {
 
     this.doneButton = new LargeButton({ text: '완료' });
     this.doneButton.y = this.panelBase.boxHeight * 0.5 - 78;
-    this.doneButton.onPress.connect(() => navigation.dismissPopup());
+    this.doneButton.onPress.connect(this.handleDoneButton);
     this.panel.addChild(this.doneButton);
 
     this.versionLabel = new Label(`게임 버전 ${GAMEVERSION}`, {
@@ -91,6 +94,20 @@ export class SettingsPopup extends Container {
     });
     this.layout.addChild(this.sfxSlider);
   }
+
+  public handleDoneButton = async () => {
+    try {
+      const gameStats = storage.getObject('game-stats');
+
+      if (gameStats.state === 'IN_PROGRESS') {
+        await gameResume(gameStats.sessionId);
+      }
+
+      navigation.dismissPopup();
+    } catch (error) {
+      eventEmitter.emit('error', error);
+    }
+  };
 
   /** 창 크기가 변경될 때마다 팝업 크기 조정 */
   public resize(width: number, height: number) {

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -53,16 +53,14 @@ export class GameScreen extends Container {
       ripple: 'ripple',
     });
 
-    this.settingsButton.onPress.connect(() =>
-      this.handlePopUpButton('setting'),
-    );
+    this.settingsButton.onPress.connect(() => this.handlePopUpButton());
     this.addChild(this.settingsButton);
 
     this.pauseButton = new IconButton({
       image: 'pause',
       ripple: 'ripple',
     });
-    this.pauseButton.onPress.connect(() => this.handlePopUpButton('pause'));
+    this.pauseButton.onPress.connect(() => navigation.presentPopup(PausePopup));
 
     this.addChild(this.pauseButton);
 
@@ -89,13 +87,13 @@ export class GameScreen extends Container {
     this.addChild(this.beforGameStart);
   }
 
-  public handlePopUpButton = async (popup: 'pause' | 'setting') => {
+  public handlePopUpButton = async () => {
     try {
       const gameStats = storage.getObject('game-stats');
       if (!gameStats) throw new Error('게임 세션을 찾을 수 없습니다.');
 
       await gamePause(gameStats.sessionId);
-      navigation.presentPopup(popup === 'pause' ? PausePopup : SettingsPopup);
+      navigation.presentPopup(SettingsPopup);
     } catch (error) {
       eventEmitter.emit('error', error);
     }
@@ -210,7 +208,7 @@ export class GameScreen extends Container {
   }
 
   /** URL이 변경되면 자동 정지 */
-  public blur() {
+  public async blur() {
     if (!navigation.currentPopup && this.snackGame.isPlaying()) {
       navigation.presentPopup(PausePopup);
     }

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -5,18 +5,21 @@ import PATH from '@constants/path.constant';
 
 import { ResultScreen } from './ResultScreen';
 import { PausePopup } from '../popup/PausePopup';
+import { SettingsPopup } from '../popup/SettingPopup';
 import { SnackGame, SnackGameOnPopData } from '../snackGame/SnackGame';
 import { SnackGameMode, snackGameGetConfig } from '../snackGame/SnackGameUtil';
+import { eventEmitter } from '../SnackGameBase';
 import { BeforGameStart } from '../ui/BeforeGameStart';
 import { GameEffects } from '../ui/GameEffect';
 import { IconButton } from '../ui/IconButton';
 import { Score } from '../ui/Score';
-import { SettingsPopup } from '../ui/SettingPopup';
 import { Timer } from '../ui/Timer';
+import { gameEnd, gamePause, gameScore, gameStart } from '../util/api';
 import { waitFor } from '../util/asyncUtils';
 import { bgm } from '../util/audio';
 import { getUrlParam } from '../util/getUrlParams';
 import { navigation } from '../util/navigation';
+import { storage } from '../util/storage';
 import { userStats } from '../util/userStats';
 
 export class GameScreen extends Container {
@@ -51,7 +54,7 @@ export class GameScreen extends Container {
     });
 
     this.settingsButton.onPress.connect(() =>
-      navigation.presentPopup(SettingsPopup),
+      this.handlePopUpButton('setting'),
     );
     this.addChild(this.settingsButton);
 
@@ -59,7 +62,7 @@ export class GameScreen extends Container {
       image: 'pause',
       ripple: 'ripple',
     });
-    this.pauseButton.onPress.connect(() => navigation.presentPopup(PausePopup));
+    this.pauseButton.onPress.connect(() => this.handlePopUpButton('pause'));
 
     this.addChild(this.pauseButton);
 
@@ -85,6 +88,18 @@ export class GameScreen extends Container {
     this.beforGameStart = new BeforGameStart();
     this.addChild(this.beforGameStart);
   }
+
+  public handlePopUpButton = async (popup: 'pause' | 'setting') => {
+    try {
+      const gameStats = storage.getObject('game-stats');
+      if (!gameStats) throw new Error('게임 세션을 찾을 수 없습니다.');
+
+      await gamePause(gameStats.sessionId);
+      navigation.presentPopup(popup === 'pause' ? PausePopup : SettingsPopup);
+    } catch (error) {
+      eventEmitter.emit('error', error);
+    }
+  };
 
   public prepare() {
     const mode = getUrlParam('mode') as SnackGameMode;
@@ -218,11 +233,23 @@ export class GameScreen extends Container {
 
   /** 게임 플레이를 마무리하고 결과를 userStats에 저장함 */
   private async finish() {
-    if (this.finished) return;
-    this.finished = true;
-    this.snackGame.stopPlaying();
-    const performance = this.snackGame.stats.getGameplayPerformance();
-    userStats.save(this.snackGame.config.mode, performance);
-    navigation.showScreen(ResultScreen);
+    try {
+      if (this.finished) return;
+      this.finished = true;
+      this.snackGame.stopPlaying();
+
+      const performance = this.snackGame.stats.getGameplayPerformance();
+      userStats.save(this.snackGame.config.mode, performance);
+
+      const gameStats = storage.getObject('game-stats');
+      if (!gameStats) throw new Error('게임 세션을 찾을 수 없습니다.');
+
+      await gameScore(performance.score, gameStats.sessionId);
+      const data = await gameEnd(gameStats.sessionId);
+      storage.setObject('game-stats', { ...data });
+      navigation.showScreen(ResultScreen);
+    } catch (error) {
+      eventEmitter.emit('error', error);
+    }
   }
 }

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -53,7 +53,9 @@ export class GameScreen extends Container {
       ripple: 'ripple',
     });
 
-    this.settingsButton.onPress.connect(() => this.handlePopUpButton());
+    this.settingsButton.onPress.connect(() =>
+      navigation.presentPopup(SettingsPopup),
+    );
     this.addChild(this.settingsButton);
 
     this.pauseButton = new IconButton({
@@ -86,18 +88,6 @@ export class GameScreen extends Container {
     this.beforGameStart = new BeforGameStart();
     this.addChild(this.beforGameStart);
   }
-
-  public handlePopUpButton = async () => {
-    try {
-      const gameStats = storage.getObject('game-stats');
-      if (!gameStats) throw new Error('게임 세션을 찾을 수 없습니다.');
-
-      await gamePause(gameStats.sessionId);
-      navigation.presentPopup(SettingsPopup);
-    } catch (error) {
-      eventEmitter.emit('error', error);
-    }
-  };
 
   public prepare() {
     const mode = getUrlParam('mode') as SnackGameMode;

--- a/src/pages/games/SnackGame/game/screen/LobbyScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/LobbyScreen.ts
@@ -18,8 +18,6 @@ export class LobbyScreen extends Container {
 
   /** 기본 모드 시작 버튼 */
   private defaultModButton: LargeButton;
-  /** 무한 모드 시작 버튼 */
-  private infModButton: LargeButton;
   /** wave 효과 */
   private waves: Waves;
   /** snack game letter logo */
@@ -49,17 +47,8 @@ export class LobbyScreen extends Container {
       setUrlParam('mode', 'default');
       navigation.showScreen(GameScreen);
     });
+
     this.addChild(this.defaultModButton);
-
-    this.infModButton = new LargeButton({
-      text: t('infinite_mode', { ns: 'game' }),
-    });
-    this.infModButton.onPress.connect(() => {
-      setUrlParam('mode', 'inf');
-      navigation.showScreen(GameScreen);
-    });
-    this.addChild(this.infModButton);
-
     this.snackGameLetter = new SnackGameLetter();
     this.addChild(this.snackGameLetter);
   }
@@ -67,14 +56,9 @@ export class LobbyScreen extends Container {
   /** 화면 크기 변경 시 트리거 됩니다. */
   public resize(width: number, height: number) {
     this.defaultModButton.x = width * 0.5;
-    this.defaultModButton.y = height * 0.6;
+    this.defaultModButton.y = height * 0.8;
     this.defaultModButton.width = width * 0.5;
     this.defaultModButton.height = height * 0.1;
-
-    this.infModButton.x = width * 0.5;
-    this.infModButton.y = height * 0.75;
-    this.infModButton.width = width * 0.5;
-    this.infModButton.height = height * 0.1;
 
     this.waves.x = 0;
     this.waves.y = height;
@@ -92,7 +76,6 @@ export class LobbyScreen extends Container {
     bgm.play('common/bgm-lobby.mp3', { volume: 0.5 });
 
     this.defaultModButton.hide(false);
-    this.infModButton.hide(false);
     this.settingsButton.hide(false);
     this.snackGameLetter.hide(false);
 
@@ -106,14 +89,12 @@ export class LobbyScreen extends Container {
 
     this.snackGameLetter.show();
     this.defaultModButton.show();
-    this.infModButton.show();
     this.settingsButton.show();
   }
 
   /** Screen 시작 시 보여지는 애니메이션 입니다. */
   public async hide() {
     this.defaultModButton.hide();
-    this.infModButton.hide();
     this.snackGameLetter.hide();
     this.settingsButton.hide(false);
 

--- a/src/pages/games/SnackGame/game/screen/ResultScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/ResultScreen.ts
@@ -3,14 +3,17 @@ import { t } from 'i18next';
 import { Container } from 'pixi.js';
 
 import { GameScreen } from './GameScreen';
-import { app } from '../SnackGameBase';
+import { SettingsPopup } from '../popup/SettingPopup';
+import { app, eventEmitter } from '../SnackGameBase';
 import { IconButton } from '../ui/IconButton';
 import { Label } from '../ui/Label';
 import { LargeButton } from '../ui/LargeButton';
-import { SettingsPopup } from '../ui/SettingPopup';
 import { Waves } from '../ui/Waves';
+import { gameStart } from '../util/api';
 import { bgm } from '../util/audio';
+import { setUrlParam } from '../util/getUrlParams';
 import { navigation } from '../util/navigation';
+import { storage } from '../util/storage';
 import { userSettings } from '../util/userSetting';
 import { userStats } from '../util/userStats';
 
@@ -56,10 +59,20 @@ export class ResultScreen extends Container {
       text: t('restart', { ns: 'game' }),
     });
     this.addChild(this.continueButton);
-    this.continueButton.onPress.connect(() =>
-      navigation.showScreen(GameScreen),
-    );
+    this.continueButton.onPress.connect(this.handleGameStartButton);
   }
+
+  /** 게임 시작 버튼 */
+  public handleGameStartButton = async () => {
+    try {
+      const data = await gameStart();
+      storage.setObject('game-stats', { ...data });
+      setUrlParam('mode', 'default');
+      navigation.showScreen(GameScreen);
+    } catch (error) {
+      eventEmitter.emit('error', error);
+    }
+  };
 
   /** 화면 크기 변경 시 트리거 됩니다. */
   public resize(width: number, height: number) {

--- a/src/pages/games/SnackGame/game/util/api.ts
+++ b/src/pages/games/SnackGame/game/util/api.ts
@@ -1,0 +1,47 @@
+import api from '@api/index';
+
+import {
+  SnackGameDefalutResponse,
+  SnackGameEnd,
+  SnackGamePauese,
+  SnackGameStart,
+} from '../game.type';
+
+export const gameStart = async (): Promise<SnackGameStart> => {
+  const { data } = await api.post('/games/2');
+
+  return data;
+};
+
+export const gameScore = async (
+  score: number,
+  sessionId: number,
+): Promise<SnackGameDefalutResponse> => {
+  const { data } = await api.put(`/games/2/${sessionId}`, {
+    score,
+  });
+
+  return data;
+};
+
+export const gamePause = async (
+  sessionId: number,
+): Promise<SnackGamePauese> => {
+  const { data } = await api.post(`games/2/${sessionId}/pause`);
+
+  return data;
+};
+
+export const gameResume = async (
+  sessionId: number,
+): Promise<SnackGameDefalutResponse> => {
+  const { data } = await api.post(`games/2/${sessionId}/resume`);
+
+  return data;
+};
+
+export const gameEnd = async (sessionId: number): Promise<SnackGameEnd> => {
+  const { data } = await api.post(`games/2/${sessionId}/end`);
+
+  return data;
+};

--- a/src/pages/games/SnackGame/ranking/RankingPage.tsx
+++ b/src/pages/games/SnackGame/ranking/RankingPage.tsx
@@ -2,7 +2,9 @@ import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useTranslation } from 'react-i18next';
 
+import QueryBoundary from '@components/base/QueryBoundary';
 import Dropdown, { DropDownOptionType } from '@components/DropDown/DropDown';
+import RetryError from '@components/Error/RetryError';
 import Spacing from '@components/Spacing/Spacing';
 import RankingSection from '@pages/games/SnackGame/ranking/components/RankingSection';
 
@@ -44,7 +46,9 @@ const RankingPage = () => {
         />
       </div>
       <Spacing size={6} />
-      <RankingSection season={selectedSeason} />
+      <QueryBoundary errorFallback={RetryError}>
+        <RankingSection season={selectedSeason} />
+      </QueryBoundary>
     </>
   );
 };

--- a/src/utils/atoms/common.atom.ts
+++ b/src/utils/atoms/common.atom.ts
@@ -17,7 +17,7 @@ export const toastState = atom<toastStateType>({
   default: {
     id: TOAST_ID,
     message: '',
-    type: undefined,
+    type: 'success',
   },
 });
 

--- a/src/utils/types/common.type.ts
+++ b/src/utils/types/common.type.ts
@@ -13,7 +13,7 @@ export interface ModalType {
 export interface toastStateType {
   id?: string;
   message: string;
-  type?: ToastType;
+  type: ToastType;
 }
 
 export type RankingType = {


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 신규 피처
- #231 
## 📋 변경 및 추가 사항
# 에러 핸들링 개선
기존에 message만 노출하던 RetryError, ErrorPage를 수정해 error code도 보여줄 수 있도록 변경했습니다.
```typescript
export interface FallbackProps {
  error?: Error & { code?: string };
  resetErrorBoundary?: () => void;
  message?: string;
}
```
## 누락된 RankingPage QueryBoundary추가
RankingPage에 QueryBoundary가 누락된걸로 보여 컴포넌트 단위의 핸들링을 위해 QueryBoundary를 추가했습니다.

# Pixi 에러 핸들링 전략
Pixi 의 경우 React 환경 바깥에서 동작하는 객체이기 때문에 내부에서 발생한 오류가 Errorboundary로 전파되지 않습니다.
이를 해결하기 위해 이벤트 기반 통신을 지원하는 Pixi의 EventEmitter 객체를 사용했습니다.
아래는 SnackGame 에러 핸들링을 도식화 한 그림입니다.
![image](https://github.com/snack-game/front/assets/16986867/212f0ef6-607e-418e-8050-670ea518bded)
EventEmitter의 이벤트는 SnackGameBase 렌더링 시 useEffect에 의해 등록되고 해제됩니다.
Pixi에서는 기본적으로 try - catch를 사용해 비동기 작업의 에러를 잡고 EventEmitter의 emit 메서드를 통해 error 객체를 전달해 이벤트를 트리거 합니다.
Emitter에 등록된 handler 함수가 useError의 setError 함수를 호출하고 useErrror의 useEffect 내부에서 error를 throw합니다.
useEffect 내부에서 Error를 throw 하기에 React 라이프 사이클 내에서 발생한 오류로 식별하고 ErrorBoundary가 에러를 잡아낼 수 있게 됩니다.

# Pixi API연동
기본적인 API 호출은 기존과 동일하게 axios를 사용해 호출합니다.
API는 시작, 정지, 재시작, 종료와 같은 게임 상태를 관리하기에 응답들은 모두 storage 함수를 통해 localstorage에 저장됩니다.
PuasePopup, SettingPopup등 일시 정지, 재시작과 관련된 요소들은 localstorage에 저장된 game-stats를 참고해 api를 호출 여부를 결정하고 호출하게 됩니다.
각 API호출 후 게임 상태를 반영하기 위해 API응답을 storage에 저장하게 됩니다.
```typescript
    try {
      const gameStats = storage.getObject('game-stats');
      if (!gameStats) throw new Error('세션을 찾을 수 없습니다.');
      const data = await gamePause(gameStats.sessionId);
      storage.setObject('game-stats', { ...data });
    } catch (error) {
      eventEmitter.emit('error', error);
    }
```

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
