### PR TITLE
fix: webview로 접근할 경우 `GameLayout`에서 프로필 요청을 보낸다

### DIFF
--- a/src/pages/GameLayout.tsx
+++ b/src/pages/GameLayout.tsx
@@ -19,7 +19,7 @@ const GameLayout = () => {
       setUserState({ ...profile });
     };
 
-    if (window.navigator.userAgent.includes('RN')) {
+    if (window.navigator.userAgent.includes('SnackgameApp')) {
       updateProfile();
       return;
     }

--- a/src/pages/GameLayout.tsx
+++ b/src/pages/GameLayout.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react';
 import { Outlet, useNavigate } from 'react-router-dom';
 
-import { useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 
+import membersApi from '@api/members.api';
 import { BottomNav } from '@components/BottomNav/BottomNav';
 import { userState } from '@utils/atoms/member.atom';
 
@@ -10,9 +11,19 @@ import PATH from '@constants/path.constant';
 
 const GameLayout = () => {
   const navigate = useNavigate();
-  const userStateValue = useRecoilValue(userState);
+  const [userStateValue, setUserState] = useRecoilState(userState);
 
   useEffect(() => {
+    const updateProfile = async () => {
+      const profile = await membersApi.getMemberProfile();
+      setUserState({ ...profile });
+    };
+
+    if (window.navigator.userAgent.includes('RN')) {
+      updateProfile();
+      return;
+    }
+
     if (!userStateValue.id) {
       navigate(PATH.AUTH, { replace: true });
     }

--- a/src/pages/user/setting/SettingPage.tsx
+++ b/src/pages/user/setting/SettingPage.tsx
@@ -30,6 +30,7 @@ const SettingPage = () => {
     await authApi.logOut();
     openToast(t('login_logout'), 'success');
     deleteStorageValue();
+    window.dispatchEvent(new Event('loggedOut'));
     navigate(PATH.AUTH, { replace: true });
   };
 


### PR DESCRIPTION
## 💻 개요

- 이슈대응
- #245

## 📋 변경 및 추가 사항

- 웹뷰로 스낵게임에 접근할 경우 전역상태를 업데이트 하는 코드를 `GameLayout`에 추가했습니다

## 💬 To. 리뷰어

@0chil

[웹뷰 문서](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#useragent) 보니까 `WebView` 쓸 때 userAgent 설정이 가능하던데, 
기존 userAgent 뒤에 적당한 문자열 하나 붙여서 보내주실 수 있을까요? (일단은 'RN'으로 해둔 상태)

모바일 웹과 웹뷰를 구분하려면 이 과정이 필요할 거 같습니다!!


