### PR TITLE
feat: 앱 백그라운드 시 게임을 일시정지한다

### DIFF
--- a/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
+++ b/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
@@ -27,6 +27,24 @@ const initializeApplication = ({
   const [pixiValue, setPixiValue] = useRecoilState(pixiState);
   const setError = useError();
 
+  const appBackgroundListener = (message: any) => {
+    try {
+      const parsed = JSON.parse(message.data);
+      if (parsed.event === 'app-background') {
+        application.onPause();
+      }
+    } finally {
+      // no-op
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('message', appBackgroundListener);
+    return () => {
+      window.removeEventListener('message', appBackgroundListener);
+    };
+  }, []);
+
   useEffect(() => {
     application.setError = setError;
     initCanvas().then(loadAdditional);
@@ -39,7 +57,7 @@ const initializeApplication = ({
   const initCanvas = async () => {
     try { // TODO: 다시 로드할 필요가 없도록 어플리케이션을 유지해야 합니다.
 
-      if(!pixiValue.pixiInit){
+      if (!pixiValue.pixiInit) {
         // const application = new SnackgameApplication(new AppScreenPool(), setError);
 
         await application.init({
@@ -51,20 +69,17 @@ const initializeApplication = ({
         });
 
         setPixiValue((pre) => ({ ...pre, pixiInit: true }));
-
       }
-
     } catch (e) {
       console.log(e);
       setError(new Error('Pixi 어플리케이션 초기화에 실패했습니다.'));
     }
-    application.onResume();
     canvasBaseRef.current?.appendChild(application.canvas);
   };
 
   const loadAdditional = async () => {
     try {
-      if(!pixiValue.assetsInit){
+      if (!pixiValue.assetsInit) {
         await initAssets();
         const loadScreen = new LoadScreen();
         const loadScreenPromise = application.showAppScreen(loadScreen);

--- a/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
+++ b/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
@@ -32,7 +32,7 @@ const initializeApplication = ({
     initCanvas().then(loadAdditional);
 
     return () => {
-      application.stop();
+      application.onPause();
     };
   }, []);
 
@@ -58,7 +58,7 @@ const initializeApplication = ({
       console.log(e);
       setError(new Error('Pixi 어플리케이션 초기화에 실패했습니다.'));
     }
-    application.start()
+    application.onResume();
     canvasBaseRef.current?.appendChild(application.canvas);
   };
 

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -130,7 +130,7 @@ export class GameScreen extends Container implements AppScreen {
       this.snackGame.isPlaying() &&
       window.location.pathname !== PATH.SNACK_GAME
     ) {
-      this.blur();
+      this.onPause();
     }
   }
 
@@ -203,10 +203,9 @@ export class GameScreen extends Container implements AppScreen {
     this.snackGame.startPlaying();
   }
 
-  public async blur() {
-    if (!this.app.currentPopup && this.snackGame.isPlaying()) {
-      this.app.presentPopup(PausePopup);
-    }
+  public async onPause() {
+    await this.handleGamePause();
+    this.app.presentPopup(PausePopup);
   }
 
   public async onHide({ width, height }: Rectangle) {

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -146,14 +146,14 @@ export class GameScreen extends Container implements AppScreen {
     this.score.upWavesPosition();
   }
 
-  /** 게임을 일시 정지 합니다. */
-  public async pause() {
+  public async onPause() {
+    await this.handleGamePause();
     this.gameContainer.interactiveChildren = false;
     this.snackGame.pause();
+    this.app.presentPopup(PausePopup);
   }
 
-  /** 게임 재게 */
-  public async resume() {
+  public async onResume() {
     this.gameContainer.interactiveChildren = true;
     this.snackGame.resume();
   }
@@ -201,11 +201,6 @@ export class GameScreen extends Container implements AppScreen {
     await waitFor(0.6);
     await this.beforGameStart.hide();
     this.snackGame.startPlaying();
-  }
-
-  public async onPause() {
-    await this.handleGamePause();
-    this.app.presentPopup(PausePopup);
   }
 
   public async onHide({ width, height }: Rectangle) {

--- a/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
+++ b/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
@@ -41,15 +41,8 @@ export class SnackgameApplication extends Application {
   }
 
   onPause(): void {
-    // Hook
     console.log('Application paused');
     this.currentAppScreen?.onPause?.();
-    this.stop();
-  }
-
-   onResume() {
-    console.log('Application resumed');
-    this.start();
   }
 
   public async show(ctor: AppScreenConstructor) {
@@ -70,7 +63,7 @@ export class SnackgameApplication extends Application {
   public async presentPopup(ctor: AppScreenConstructor) {
     if (this.currentAppScreen) {
       this.currentAppScreen.interactiveChildren = false;
-      await this.currentAppScreen.pause?.();
+      await this.currentAppScreen.onPause?.();
       this.currentAppScreen.filters = [new BlurFilter({ strength: 4 })];
     }
     if (this.currentPopup) {
@@ -90,26 +83,10 @@ export class SnackgameApplication extends Application {
     await this.hideAndReset(this.currentPopup);
     if (this.currentAppScreen) {
       this.currentAppScreen.interactiveChildren = true;
-      this.currentAppScreen.resume?.();
+      this.currentAppScreen.onResume?.();
       this.currentAppScreen.filters = [];
     }
     this.currentPopup = undefined;
-  }
-
-  /**
-   * 포커스를 잃었을 때 화면 흐리게 하기
-   */
-  public blur() {
-    this.currentAppScreen?.onPause?.();
-    this.currentPopup?.onPause?.();
-  }
-
-  /**
-   * 화면에 포커스 주기
-   */
-  public focus() {
-    this.currentAppScreen?.focus?.();
-    this.currentPopup?.focus?.();
   }
 
   private async prepareAndShow(appScreen: AppScreen) {

--- a/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
+++ b/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
@@ -40,15 +40,16 @@ export class SnackgameApplication extends Application {
     this.renderer.on('resize', () => this.resizeChildren()); // TODO: delayed resize
   }
 
-  public override stop() {
+  onPause(): void {
     // Hook
-    console.log("Application stopped");
-    super.stop();
+    console.log('Application paused');
+    this.currentAppScreen?.onPause?.();
+    this.stop();
   }
 
-  public override start() {
-    console.log("Application started");
-    super.start();
+   onResume() {
+    console.log('Application resumed');
+    this.start();
   }
 
   public async show(ctor: AppScreenConstructor) {
@@ -99,8 +100,8 @@ export class SnackgameApplication extends Application {
    * 포커스를 잃었을 때 화면 흐리게 하기
    */
   public blur() {
-    this.currentAppScreen?.blur?.();
-    this.currentPopup?.blur?.();
+    this.currentAppScreen?.onPause?.();
+    this.currentPopup?.onPause?.();
   }
 
   /**

--- a/src/pages/games/SnackGame/game/screen/appScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/appScreen.ts
@@ -8,10 +8,7 @@ export interface AppScreen extends Container {
     onHide(screen: Rectangle): Promise<void>;
     onResize(screen: Rectangle): void;
     onPause?(): Promise<void>;
-    /** 화면을 일시 정지 */
-    pause?(): Promise<void>;
-    /** 화면을 재개 */
-    resume?(): Promise<void>;
+    onResume?(): Promise<void>;
     /** 숨겨진 후 화면 재설정 */
     reset?(): void;
     /** 화면 업데이트, 델타 시간/단계 전달 */

--- a/src/pages/games/SnackGame/game/screen/appScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/appScreen.ts
@@ -7,6 +7,7 @@ export interface AppScreen extends Container {
     onShow(screen: Rectangle): Promise<void>;
     onHide(screen: Rectangle): Promise<void>;
     onResize(screen: Rectangle): void;
+    onPause?(): Promise<void>;
     /** 화면을 일시 정지 */
     pause?(): Promise<void>;
     /** 화면을 재개 */
@@ -15,8 +16,6 @@ export interface AppScreen extends Container {
     reset?(): void;
     /** 화면 업데이트, 델타 시간/단계 전달 */
     update?(time: Ticker): void;
-    /** 화면 흐리게 하기 */
-    blur?(): void;
     /** 화면에 포커스 */
     focus?(): void;
   }


### PR DESCRIPTION
## 💻 개요
- resolves: #248 

## 📋 변경 및 추가 사항
#### `AppScreen` 인터페이스의 `pause`/`resume` 메서드를 `onPause`/`onResume`으로 재명명했습니다.
- 해당 상황 발생 시 수동적으로 처리한다는 의미입니다. (이벤트 구조를 떠올리면 이해가 쉬울 것 같습니다)
- 개발자가 이 메서드를 직접 호출할 일은 없으며, 모두 `SnackgameApplication`이 적절히 처리합니다.

#### 앱 백그라운드 시 일시정지
앱이 백그라운드로 갈 때 발송하는 `{event: 'app-background'}` 메시지를 받아 `onPause()`를 실행하게 하였습니다.
`onPause?()`는 optional이므로, 해당 메서드가 있는 경우에만 실행됩니다. (현재 `GameScreen`에서만 실행)

## 💬 To. 리뷰어

