### PR TITLE
fix: 앱 백그라운드시 게임을 일시정지한다

### DIFF
--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -10,7 +10,13 @@ import { SettingsPopup } from './popup/SettingPopup';
 import { GameScreen } from './screen/GameScreen';
 import { LobbyScreen } from './screen/LobbyScreen';
 import { SnackgameApplication } from './screen/SnackgameApplication';
-import { gameEnd, gamePause, gameResume, gameScore, gameStart } from './util/api';
+import {
+  gameEnd,
+  gamePause,
+  gameResume,
+  gameScore,
+  gameStart,
+} from './util/api';
 
 type Props = {
   replaceErrorHandler: (handler: () => void) => void;
@@ -26,7 +32,18 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
       [SettingsPopup, () => new SettingsPopup(application, handleGameResume)],
       [PausePopup, () => new PausePopup(application, handleGameResume)],
       [LobbyScreen, () => new LobbyScreen(application, handleSetMode)],
-      [GameScreen, () => new GameScreen(application, handleGetMode, handleStreak, handleGameStart, handleGamePause, handleGameEnd)],
+      [
+        GameScreen,
+        () =>
+          new GameScreen(
+            application,
+            handleGetMode,
+            handleStreak,
+            handleGameStart,
+            handleGamePause,
+            handleGameEnd,
+          ),
+      ],
     );
     return application.appScreenPool;
   };
@@ -35,7 +52,9 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
     initializeAppScreens,
   });
 
-  const handleApplicationError = () => { application.show(LobbyScreen) };
+  const handleApplicationError = () => {
+    application.show(LobbyScreen);
+  };
 
   // 게임 진행 관련 functions
   let session: SnackGameDefalutResponse | undefined;
@@ -61,15 +80,15 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
     await gameScore(session!.score, session!.sessionId);
   };
 
-  const handleGamePause = async ()=>{
-    if(!session) return;
-    await gamePause(session!.sessionId);
-  }
+  const handleGamePause = async () => {
+    if (!session || session.state === 'PAUSED') return;
+    session = await gamePause(session!.sessionId);
+  };
 
-  const handleGameResume = async ()=>{
-    if(!session) return;
+  const handleGameResume = async () => {
+    if (!session) return;
     await gameResume(session!.sessionId);
-  }
+  };
 
   const handleGameEnd = async () => {
     const data = await gameEnd(session!.sessionId);

--- a/src/pages/games/SnackGame/game/SnackGamePage.tsx
+++ b/src/pages/games/SnackGame/game/SnackGamePage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 
 import ErrorBoundary from '@components/base/ErrorBoundary';
@@ -7,9 +6,10 @@ import RetryError from '@components/Error/RetryError';
 import SnackGameBase from './SnackGameBase';
 
 const SnackGamePage = () => {
-  const [errorHandler, replaceErrorHandler] = useState<() => void>(() => {
-    // no-op
-  });
+  let errorHandler = () => {
+    console.log('SnackgameBase 초기화 전 오류가 발생했습니다');
+  };
+  const replaceErrorHandler = (handler: () => void) => (errorHandler = handler);
 
   return (
     <>

--- a/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
+++ b/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
@@ -27,7 +27,7 @@ const initializeApplication = ({
   const setError = useError();
 
   const appBackgroundListener = (event: MessageEvent) => {
-    if (!event.source && event.data.contains('app-')) {
+    if (!event.source && event.data.includes('app-')) {
       const parsed = JSON.parse(event.data);
       if (parsed.event === 'app-background') {
         application.onPause();

--- a/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
+++ b/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
@@ -17,8 +17,7 @@ interface Props {
   initializeAppScreens: (app: SnackgameApplication) => Promise<AppScreenPool>;
 }
 
-const errorHandler = (e:any)=>{console.log("no error handler yet")};
-const application = new SnackgameApplication(new AppScreenPool(), errorHandler);
+const application = new SnackgameApplication(new AppScreenPool());
 
 const initializeApplication = ({
   canvasBaseRef,
@@ -27,14 +26,12 @@ const initializeApplication = ({
   const [pixiValue, setPixiValue] = useRecoilState(pixiState);
   const setError = useError();
 
-  const appBackgroundListener = (message: any) => {
-    try {
-      const parsed = JSON.parse(message.data);
+  const appBackgroundListener = (event: MessageEvent) => {
+    if (!event.source && event.data.contains('app-')) {
+      const parsed = JSON.parse(event.data);
       if (parsed.event === 'app-background') {
         application.onPause();
       }
-    } finally {
-      // no-op
     }
   };
 
@@ -55,11 +52,8 @@ const initializeApplication = ({
   }, []);
 
   const initCanvas = async () => {
-    try { // TODO: 다시 로드할 필요가 없도록 어플리케이션을 유지해야 합니다.
-
+    try {
       if (!pixiValue.pixiInit) {
-        // const application = new SnackgameApplication(new AppScreenPool(), setError);
-
         await application.init({
           resizeTo: canvasBaseRef.current!,
           resolution: Math.max(window.devicePixelRatio, 2),

--- a/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
+++ b/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
@@ -30,7 +30,12 @@ const initializeApplication = ({
     if (!event.source && event.data.includes('app-')) {
       const parsed = JSON.parse(event.data);
       if (parsed.event === 'app-background') {
-        application.onPause();
+        application.onLostFocus();
+        return;
+      }
+      if (parsed.event === 'app-foreground') {
+        application.onGotFocus();
+        return;
       }
     }
   };
@@ -45,9 +50,10 @@ const initializeApplication = ({
   useEffect(() => {
     application.setError = setError;
     initCanvas().then(loadAdditional);
-
+    
+    application.onGotFocus();
     return () => {
-      application.onPause();
+      application.onLostFocus();
     };
   }, []);
 

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -1,9 +1,7 @@
 import gsap from 'gsap';
 import { Container, Rectangle, Ticker } from 'pixi.js';
 
-import PATH from '@constants/path.constant';
-
-import { AppScreen } from './appScreen';
+import { AppScreen, AppScreenConstructor } from './appScreen';
 import { SnackgameApplication } from './SnackgameApplication';
 import { PausePopup } from '../popup/PausePopup';
 import { SettingsPopup } from '../popup/SettingPopup';
@@ -56,8 +54,7 @@ export class GameScreen extends Container implements AppScreen {
     });
 
     this.settingsButton.onPress.connect(async () => {
-      await handleGamePause();
-      app.presentPopup(SettingsPopup);
+      await this.onPause(SettingsPopup);
     });
     this.addChild(this.settingsButton);
 
@@ -66,8 +63,7 @@ export class GameScreen extends Container implements AppScreen {
       ripple: 'ripple',
     });
     this.pauseButton.onPress.connect(async () => {
-      await handleGamePause();
-      app.presentPopup(PausePopup);
+      await this.onPause();
     });
 
     this.addChild(this.pauseButton);
@@ -81,7 +77,7 @@ export class GameScreen extends Container implements AppScreen {
     this.snackGame = new SnackGame();
     this.snackGame.onPop = this.onPop.bind(this);
     this.snackGame.onStreak = (data: any[]) => {
-      handleStreak(data.length);
+      this.handleStreak(data.length);
     };
     this.snackGame.onSnackGameBoardReset =
       this.onSnackGameBoardReset.bind(this);
@@ -138,12 +134,12 @@ export class GameScreen extends Container implements AppScreen {
     this.score.upWavesPosition();
   }
 
-  public async onPause() {
+  public async onPause(popup?: AppScreenConstructor) {
     if (this.snackGame.isPlaying()) {
       await this.handleGamePause();
       this.gameContainer.interactiveChildren = false;
       this.snackGame.pause();
-      this.app.presentPopup(PausePopup);
+      this.app.presentPopup(popup ? popup : PausePopup);
     }
   }
 

--- a/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
+++ b/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
@@ -2,6 +2,7 @@ import { Application, ApplicationOptions, BlurFilter } from 'pixi.js';
 
 import { AppScreen, AppScreenConstructor } from './appScreen';
 import { AppScreenPool } from './appScreenPool';
+import { bgm } from '../util/audio';
 
 export class SnackgameApplication extends Application {
   private _currentAppScreen?: AppScreen;
@@ -43,9 +44,15 @@ export class SnackgameApplication extends Application {
     this.renderer.on('resize', () => this.resizeChildren()); // TODO: delayed resize
   }
 
-  onPause(): void {
-    console.log('Application paused');
+  onLostFocus(): void {
+    console.log('SnackgameApplication lost focus');
     this.currentAppScreen?.onPause?.();
+    bgm.current?.pause()
+  }
+
+  onGotFocus(): void {
+    console.log('SnackgameApplication got focus');
+    bgm.current?.resume()
   }
 
   public async show(ctor: AppScreenConstructor) {

--- a/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
+++ b/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
@@ -30,7 +30,10 @@ export class SnackgameApplication extends Application {
 
   constructor(
     public readonly appScreenPool: AppScreenPool,
-    public setError: (error: any) => void,
+    public setError: (error: any) => void = (error: any) => {
+      console.warn('No setError yet for SnackgameApplication');
+      console.log(error);
+    },
   ) {
     super();
   }

--- a/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
+++ b/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
@@ -66,7 +66,6 @@ export class SnackgameApplication extends Application {
   public async presentPopup(ctor: AppScreenConstructor) {
     if (this.currentAppScreen) {
       this.currentAppScreen.interactiveChildren = false;
-      await this.currentAppScreen.onPause?.();
       this.currentAppScreen.filters = [new BlurFilter({ strength: 4 })];
     }
     if (this.currentPopup) {


### PR DESCRIPTION
## 💻 개요
- resolves: #250 

## 📋 변경 및 추가 사항
- 앱 백그라운드 시 게임 및 bgm을 일시정지합니다.
  - 지난 PR에서 발생한 오류도 고쳤습니다!
- 앱 복귀 시 bgm을 다시 재생합니다.

- 스낵게임 페이지 접근 시 불필요하게 실행되는 예외 핸들러를 개선하였습니다.
- `SnackgameApplication.onPause()` -> `SnackgameApplication.onLostFocus()`/`onGotFocus()`로 변경하였습니다.
  - 헷갈리지 않도록 `AppScreen.onPause()`/`onResume()`과 의미를 구분하였습니다.

## 💬 To. 리뷰어
이번 PR이 찐찐막입니다 ㅠㅠ