### PR TITLE
refactor: 랭킹 페이지 UI, BottomNav 수정

### DIFF
--- a/src/components/BottomNav/BottomNav.tsx
+++ b/src/components/BottomNav/BottomNav.tsx
@@ -11,7 +11,7 @@ export const BottomNav = () => {
   const location = useLocation().pathname;
 
   return (
-    <div className="fixed bottom-0 z-[999] flex w-full justify-center">
+    <div className="sticky bottom-0 z-[999] flex w-full justify-center">
       <div className="flex h-16 w-full max-w-3xl items-center justify-around rounded-t-2xl bg-primary-light text-gray-500 shadow-navigation">
         <RouterLink
           to={PATH.SNACK_GAME}

--- a/src/constants/loadImage.ts
+++ b/src/constants/loadImage.ts
@@ -1,4 +1,4 @@
-import DarkOrageSnack from '@assets/images/dark_orange_snack.png';
+import DarkOrangeSnack from '@assets/images/dark_orange_snack.png';
 import GoldenSnack from '@assets/images/golden_snack.png';
 import OrangSnack from '@assets/images/orange_snack.png';
 import PlainSnack from '@assets/images/snack.png';
@@ -6,7 +6,7 @@ import PlainSnack from '@assets/images/snack.png';
 export const loadedImages = [
   PlainSnack,
   GoldenSnack,
-  DarkOrageSnack,
+  DarkOrangeSnack,
   OrangSnack,
 ].map((src) => {
   const img = new Image();

--- a/src/pages/auth/AuthPage.tsx
+++ b/src/pages/auth/AuthPage.tsx
@@ -6,7 +6,7 @@ import gsap from 'gsap';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import GoogleIcon from '@assets/icon/google.svg?react';
-import KakakoIcon from '@assets/icon/kakao.svg?react';
+import KakaoIcon from '@assets/icon/kakao.svg?react';
 import LogoImage from '@assets/images/logo-snack-game-letter.png';
 import SnackRainContainer from '@components/SnackRain/SnackRainContainer';
 import { userState } from '@utils/atoms/member.atom';
@@ -127,7 +127,7 @@ export const AuthPage = () => {
                 openOAuthDialog({ url: PATH.KAKAO, name: 'Login with KAKAO' })
               }
             >
-              <KakakoIcon className="h-10 w-10" />
+              <KakaoIcon className="h-10 w-10" />
               <span className="w-20  text-center text-sm">
                 {t('auth_kakao_button')}
               </span>

--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 import useModal from '@hooks/useModal';
 
-import { SnackGameDefalutResponse } from './game.type';
+import { SnackGameDefaultResponse } from './game.type';
 import initializeApplication from './hook/initializeApplication';
 import GameResult from './legacy/components/GameResult';
 import { PausePopup } from './popup/PausePopup';
@@ -57,7 +57,7 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
   };
 
   // 게임 진행 관련 functions
-  let session: SnackGameDefalutResponse | undefined;
+  let session: SnackGameDefaultResponse | undefined;
   let sessionMode: string | undefined;
 
   // TODO: 모드를 타입으로 정의해도 괜찮을 것 같습니다

--- a/src/pages/games/SnackGame/game/game.type.ts
+++ b/src/pages/games/SnackGame/game/game.type.ts
@@ -2,7 +2,7 @@ export type SnackGameMod = 'default' | 'inf';
 
 export type SnackGameAPIStats = 'IN_PROGRESS' | 'PAUSED' | 'EXPIRED';
 
-export interface SnackGameDefalutResponse {
+export interface SnackGameDefaultResponse {
   metadata: {
     gameId: number;
     localizedName: string;
@@ -15,10 +15,10 @@ export interface SnackGameDefalutResponse {
   board: string;
 }
 
-export type SnackGameStart = SnackGameDefalutResponse;
+export type SnackGameStart = SnackGameDefaultResponse;
 
-export type SnackGamePauese = SnackGameDefalutResponse;
+export type SnackGamePause = SnackGameDefaultResponse;
 
-export type SnackGameEnd = SnackGameDefalutResponse & {
+export type SnackGameEnd = SnackGameDefaultResponse & {
   percentile: number;
 };

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -7,7 +7,7 @@ import { PausePopup } from '../popup/PausePopup';
 import { SettingsPopup } from '../popup/SettingPopup';
 import { SnackGame, SnackGameOnPopData } from '../snackGame/SnackGame';
 import { SnackGameMode, snackGameGetConfig } from '../snackGame/SnackGameUtil';
-import { BeforGameStart } from '../ui/BeforeGameStart';
+import { BeforeGameStart } from '../ui/BeforeGameStart';
 import { GameEffects } from '../ui/GameEffect';
 import { IconButton } from '../ui/IconButton';
 import { Score } from '../ui/Score';
@@ -32,7 +32,7 @@ export class GameScreen extends Container implements AppScreen {
   /** 게임 효과 */
   public readonly vfx?: GameEffects;
   /** 게임 시작 전 준비 화면 */
-  public readonly beforGameStart: BeforGameStart;
+  public readonly beforeGameStart: BeforeGameStart;
   /** 설정 버튼 */
   private settingsButton: IconButton;
   /** 게임 종료시 true가 됩니다. */
@@ -90,8 +90,8 @@ export class GameScreen extends Container implements AppScreen {
     this.score = new Score();
     this.addChild(this.score);
 
-    this.beforGameStart = new BeforGameStart();
-    this.addChild(this.beforGameStart);
+    this.beforeGameStart = new BeforeGameStart();
+    this.addChild(this.beforeGameStart);
   }
 
   public async onPrepare({ width, height }: Rectangle) {
@@ -123,7 +123,7 @@ export class GameScreen extends Container implements AppScreen {
 
   private onSnackGameBoardReset() {
     for (const snack of this.snackGame.board.snacks) {
-      this.vfx?.animationBeforStart(snack);
+      this.vfx?.animationBeforeStart(snack);
     }
   }
 
@@ -168,8 +168,8 @@ export class GameScreen extends Container implements AppScreen {
     this.score.x = centerX;
     this.score.y = div - 80;
 
-    this.beforGameStart.x = centerX;
-    this.beforGameStart.y = centerY;
+    this.beforeGameStart.x = centerX;
+    this.beforeGameStart.y = centerY;
 
     this.pauseButton.x = 25;
     this.pauseButton.y = 25;
@@ -183,12 +183,12 @@ export class GameScreen extends Container implements AppScreen {
     this.score.show();
     this.timer.show();
     this.pauseButton.show();
-    await this.beforGameStart.show();
+    await this.beforeGameStart.show();
     await waitFor(0.3);
     this.vfx?.playPopExplosion({ x: this.score.x, y: this.score.y });
     this.onSnackGameBoardReset();
     await waitFor(0.6);
-    await this.beforGameStart.hide();
+    await this.beforeGameStart.hide();
     await this.handleGameStart();
     this.snackGame.startPlaying();
   }

--- a/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
+++ b/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
@@ -45,14 +45,12 @@ export class SnackgameApplication extends Application {
   }
 
   onLostFocus(): void {
-    console.log('SnackgameApplication lost focus');
     this.currentAppScreen?.onPause?.();
-    bgm.current?.pause()
+    bgm.current?.pause();
   }
 
   onGotFocus(): void {
-    console.log('SnackgameApplication got focus');
-    bgm.current?.resume()
+    bgm.current?.resume();
   }
 
   public async show(ctor: AppScreenConstructor) {

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameAction.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameAction.ts
@@ -22,7 +22,7 @@ export class SnackGameActions {
 
     this.updateSelectedSnacks(position);
 
-    const sum = this.snackGame.board.getSeletedSnacksSum();
+    const sum = this.snackGame.board.getSelectedSnacksSum();
 
     if (sum > 10) {
       this.snackGame.board.clearAllSelectedSnacks();

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameBoard.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameBoard.ts
@@ -211,7 +211,7 @@ export class SnackGameBoard {
   }
 
   /** 선택되 스낵의 숫자 총합 */
-  public getSeletedSnacksSum() {
+  public getSelectedSnacksSum() {
     let total = 0;
     for (const snack of this.selectedSnacks) {
       total += snack.snackNum;

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameStats.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameStats.ts
@@ -51,7 +51,7 @@ export class SnackGameStats {
    * @param playTime The play time (in milliseconds) of the score
    * @returns An number (0 to 3) representing the grade
    */
-  public caulculateGrade(score: number, playTime: number) {
+  public calculateGrade(score: number, playTime: number) {
     const avgPointsPerSecond = 8;
     const gameplayTimeInSecs = playTime / 1000;
     const pointsPerSecond = score / gameplayTimeInSecs;
@@ -76,7 +76,7 @@ export class SnackGameStats {
    * Retrieve full gameplay session performance in an object
    */
   public getGameplayPerformance() {
-    const grade = this.caulculateGrade(
+    const grade = this.calculateGrade(
       this.data.score,
       this.snackGame.timer.getTime(),
     );

--- a/src/pages/games/SnackGame/game/ui/BeforeGameStart.ts
+++ b/src/pages/games/SnackGame/game/ui/BeforeGameStart.ts
@@ -15,7 +15,7 @@ const easeMidSlowMotion = registerCustomEase(
 /**
  * 게임 시작 전 "준비 시작" 메시지를 표시하는 클래스.
  */
-export class BeforGameStart extends Container {
+export class BeforeGameStart extends Container {
   /** 내부 애니메이션을 위한 서브 컨테이너 */
   private readonly container: Container;
   /** 애니메이션된 구름 배경 */

--- a/src/pages/games/SnackGame/game/ui/GameEffect.ts
+++ b/src/pages/games/SnackGame/game/ui/GameEffect.ts
@@ -80,7 +80,7 @@ export class GameEffects extends Container {
   }
 
   /** 게임 시작 전 스낵이 위치를 찾아가는 애니메이션 */
-  public async animationBeforStart(snack: Snack) {
+  public async animationBeforeStart(snack: Snack) {
     const position = this.toLocal(snack.getGlobalPosition());
 
     const copySnack = pool.get(Snack);

--- a/src/pages/games/SnackGame/game/ui/Score.ts
+++ b/src/pages/games/SnackGame/game/ui/Score.ts
@@ -65,7 +65,7 @@ export class Score extends Container {
     this.waves.y = 40;
   }
 
-  // waves hegith 설정
+  // waves height 설정
   public set height(value: number) {
     this.waves.height = value * 2;
   }

--- a/src/pages/games/SnackGame/game/ui/Waves.ts
+++ b/src/pages/games/SnackGame/game/ui/Waves.ts
@@ -22,7 +22,7 @@ export class Waves extends Container {
     }
   }
 
-  // wave 들의 hegith 설정
+  // wave 들의 height 설정
   public set height(value: number) {
     for (const wave of this.waves) {
       wave.height = value;

--- a/src/pages/games/SnackGame/game/util/api.ts
+++ b/src/pages/games/SnackGame/game/util/api.ts
@@ -1,9 +1,9 @@
 import api from '@api/index';
 
 import {
-  SnackGameDefalutResponse,
+  SnackGameDefaultResponse,
   SnackGameEnd,
-  SnackGamePauese,
+  SnackGamePause,
   SnackGameStart,
 } from '../game.type';
 
@@ -16,7 +16,7 @@ export const gameStart = async (): Promise<SnackGameStart> => {
 export const gameScore = async (
   score: number,
   sessionId: number,
-): Promise<SnackGameDefalutResponse> => {
+): Promise<SnackGameDefaultResponse> => {
   const { data } = await api.put(`/games/2/${sessionId}`, {
     score,
   });
@@ -24,9 +24,7 @@ export const gameScore = async (
   return data;
 };
 
-export const gamePause = async (
-  sessionId: number,
-): Promise<SnackGamePauese> => {
+export const gamePause = async (sessionId: number): Promise<SnackGamePause> => {
   const { data } = await api.post(`games/2/${sessionId}/pause`);
 
   return data;
@@ -34,7 +32,7 @@ export const gamePause = async (
 
 export const gameResume = async (
   sessionId: number,
-): Promise<SnackGameDefalutResponse> => {
+): Promise<SnackGameDefaultResponse> => {
   const { data } = await api.post(`games/2/${sessionId}/resume`);
 
   return data;

--- a/src/pages/games/SnackGame/ranking/RankingPage.tsx
+++ b/src/pages/games/SnackGame/ranking/RankingPage.tsx
@@ -56,7 +56,6 @@ const RankingPage = () => {
           className="max-w-[120px]"
         />
       </div>
-      <Spacing size={6} />
       {/* TODO: 무한모드 준비 끝나면 gameId={currentTab} 으로 수정 */}
       <QueryBoundary errorFallback={RetryError}>
         <RankingSection season={selectedSeason} gameId={2} />

--- a/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
+++ b/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
@@ -32,11 +32,11 @@ const RankingSection = ({ season, gameId }: GameSeasonProps) => {
   if (totalRanking.length === 0) return <EmptyRanking />;
   return (
     <div className={'mx-auto w-full max-w-4xl'}>
-      {topRanking && <TopRanking topRanking={topRanking} />}
-      {otherRanking && <OtherRanking otherRanking={otherRanking} />}
       {userInfo.type && userInfo.type !== 'GUEST' && (
         <UserRanking season={season} gameId={gameId} />
       )}
+      {topRanking && <TopRanking topRanking={topRanking} />}
+      {otherRanking && <OtherRanking otherRanking={otherRanking} />}
     </div>
   );
 };

--- a/src/pages/games/SnackGame/ranking/components/UserRanking.tsx
+++ b/src/pages/games/SnackGame/ranking/components/UserRanking.tsx
@@ -22,7 +22,7 @@ const UserRanking = ({ season, gameId }: GameSeasonProps) => {
   return (
     <>
       {userRanking && (
-        <div className="fixed bottom-20 left-1/2 w-[90%] -translate-x-1/2 rounded-full border-2 border-primary bg-primary-light px-6 py-3 text-primary-deep-dark lg:w-1/3">
+        <div className="m-auto mb-20 mt-8 w-[90%] rounded-full border-2 border-primary bg-primary-light px-6 py-3 text-primary-deep-dark lg:w-1/3">
           <div className="flex h-full w-full items-center justify-around">
             <div className="flex flex-col">
               <div className="text-xs">{userRanking?.owner.group?.name}</div>


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 리팩토링
- #254 

## 📋 변경 및 추가 사항

- `UserRanking` 위치를 `DropDown` 아래로 이동

- `BottomNav`의 position을 sticky로 수정

= 랭킹 최하단까지 보이게 하기 위함

| before | after |
|:---:|:---:|
|![image](https://github.com/user-attachments/assets/3e0faecf-64be-4aa1-b09e-05d1e0f69e8c)|![image](https://github.com/user-attachments/assets/911a0930-b879-4f97-a33b-bdcb538b10e7)|

(그리고 아주아주 사소한 오타 수정과 console.log 2개 제거)

## 💬 To. 리뷰어

- File Change에서 한번에 보는 것보다 커밋 하나씩 넘기면서 보는 게 편할 거 같아요!

- Tab, DropDown을 합성 컴포넌트 패턴으로 개선하는 작업을 여기서 할까 했는데,
그러면 보기가 너무 불편할 거 같아 별도 이슈로 진행하겠습니다......! 넘 늦어졌군요 🥺
