### PR TITLE
feat(SnackGame): 브라우저 포커스를 잃으면 게임을 일시정지한다

### DIFF
--- a/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
+++ b/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
@@ -41,7 +41,7 @@ const initializeApplication = ({
   };
 
   const browserFocusListener = () => {
-    if (document.hidden) {
+    if (document.visibilityState === 'hidden') {
       application.onLostFocus();
       return;
     }

--- a/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
+++ b/src/pages/games/SnackGame/game/hook/initializeApplication.tsx
@@ -26,7 +26,7 @@ const initializeApplication = ({
   const [pixiValue, setPixiValue] = useRecoilState(pixiState);
   const setError = useError();
 
-  const appBackgroundListener = (event: MessageEvent) => {
+  const appFocusListener = (event: MessageEvent) => {
     if (!event.source && event.data.includes('app-')) {
       const parsed = JSON.parse(event.data);
       if (parsed.event === 'app-background') {
@@ -40,17 +40,27 @@ const initializeApplication = ({
     }
   };
 
+  const browserFocusListener = () => {
+    if (document.hidden) {
+      application.onLostFocus();
+      return;
+    }
+    application.onGotFocus();
+  };
+
   useEffect(() => {
-    window.addEventListener('message', appBackgroundListener);
+    window.addEventListener('message', appFocusListener);
+    window.addEventListener('visibilitychange', browserFocusListener);
     return () => {
-      window.removeEventListener('message', appBackgroundListener);
+      window.removeEventListener('message', appFocusListener);
+      window.removeEventListener('visibilitychange', browserFocusListener);
     };
   }, []);
 
   useEffect(() => {
     application.setError = setError;
     initCanvas().then(loadAdditional);
-    
+
     application.onGotFocus();
     return () => {
       application.onLostFocus();


### PR DESCRIPTION
## 💻 개요
- resolves: #256 

## 📋 변경 및 추가 사항
<img src="https://github.com/user-attachments/assets/5202501e-2101-481b-8c70-590f7c7b4af7" width="300">

탭을 벗어나면 게임이 일시정지됩니다.
이슈에서 언급한대로 [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API)를 사용했습니다.
오랜만에 생각한대로 쉽게 되는군요 ㄷㄷ 👍