### PR TITLE
fix: `GameResultProps`의 percentile을 필수 속성으로 변경

### DIFF
--- a/src/pages/games/SnackGame/game/legacy/components/GameResult.tsx
+++ b/src/pages/games/SnackGame/game/legacy/components/GameResult.tsx
@@ -14,7 +14,7 @@ import ExpBarChart from './ExpBarChart';
 
 interface GameResultProps {
   score: number;
-  percentile?: number;
+  percentile: number;
   reStart: () => void;
 }
 
@@ -40,7 +40,7 @@ const GameResult = ({ score, percentile, reStart }: GameResultProps) => {
 
         {userStateValue.type !== 'GUEST' && (
           <>
-            {percentile && <p>전체 사용자 중 상위 {percentile}%의 점수에요!</p>}
+            <p>전체 사용자 중 상위 {percentile}%의 점수에요!</p>
             {profile.status && <ExpBarChart status={profile.status} />}
           </>
         )}

--- a/src/pages/games/SnackGame/game/legacy/view/appleGame/ClassicMode.tsx
+++ b/src/pages/games/SnackGame/game/legacy/view/appleGame/ClassicMode.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
 
 import GameResult from '@pages/games/SnackGame/game/legacy/components/GameResult';
+import SnackGameHUD from '@pages/games/SnackGame/game/legacy/components/SnackGameHUD';
 import Apple from '@pages/games/SnackGame/game/legacy/model/appleGame/apple';
 import { AppleGame } from '@pages/games/SnackGame/game/legacy/model/appleGame/appleGame';
 import PlainApple from '@pages/games/SnackGame/game/legacy/model/appleGame/plainApple';
-import SnackGameHUD from '@pages/games/SnackGame/game/legacy/components/SnackGameHUD';
 
 import useError from '@hooks/useError';
 import useModal from '@hooks/useModal';
@@ -71,7 +71,9 @@ const ClassicMode = () => {
       openToast('게임 종료!', 'success');
 
       openModal({
-        children: <GameResult score={score} reStart={startGame} />,
+        children: (
+          <GameResult score={score} percentile={0} reStart={startGame} />
+        ),
       });
     } catch (e) {
       setError(new Error('게임 종료에 실패했습니다.'));

--- a/src/pages/games/SnackGame/game/legacy/view/snackGame/NewSnackGameMod.tsx
+++ b/src/pages/games/SnackGame/game/legacy/view/snackGame/NewSnackGameMod.tsx
@@ -8,8 +8,8 @@ import useModal from '@hooks/useModal';
 import useToast from '@hooks/useToast';
 
 import SnackGameView from './SnackGameView';
-import { GameStart } from '../../components/GameStart';
 import { SnackGameMod } from '../../../game.type';
+import { GameStart } from '../../components/GameStart';
 import { GoldenSnack } from '../../model/snackGame/goldSnack';
 import NewPlainApple from '../../model/snackGame/plainSnack';
 import NewApple from '../../model/snackGame/snack';
@@ -115,7 +115,11 @@ const NewSnackGameMod = () => {
 
       openModal({
         children: (
-          <GameResult score={score} reStart={() => startGame(snackGameMod)} />
+          <GameResult
+            score={score}
+            percentile={0}
+            reStart={() => startGame(snackGameMod)}
+          />
         ),
       });
     } catch (e) {

--- a/src/pages/games/SnackGame/game/legacy/view/snackGame/SnackGameMode.tsx
+++ b/src/pages/games/SnackGame/game/legacy/view/snackGame/SnackGameMode.tsx
@@ -97,7 +97,9 @@ const SnackGameMode = () => {
       openToast('게임 종료!', 'success');
 
       openModal({
-        children: <GameResult score={score} reStart={startGame} />,
+        children: (
+          <GameResult score={score} percentile={0} reStart={startGame} />
+        ),
       });
     } catch (e) {
       setError(new Error('게임 종료에 실패했습니다.'));


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 이슈 대응
- #258

## 📋 변경 및 추가 사항

상위 0% 일 때도 문구가 정상적으로 보이도록 코드를 수정했습니다
(사진은 **`percentile` 변수에 고의로 0 넣어서** 테스트한 거고, 34점일 때 상위 0% 아닙니다! 혹시 수상하게 생각하실까봐)

![image](https://github.com/user-attachments/assets/71887794-6014-4311-ba77-239e39be14d8)


## 💬 To. 리뷰어

아래는 구구절절 히스토리인데요 사실 굳이 안 읽으셔도 되긴 합니다 

1. 왜 `percentile = 0`일 때 0만 보였냐!

    ```tsx
    {percentile && <p>전체 사용자 중 상위 {percentile}%의 점수에요!</p>}
    ```
  
    - and 연산자는 처음으로 만나는 falsy 값을 반환함 (0은 falsy)
    - 따라서 주어진 상황에서 표현식은 아래처럼 바뀜<br/><br/>

    ```tsx
    {percentile} //  percentile 값 = 0만 출력하게 됨
    ```

2. and 연산자는 왜 썼냐

    ```tsx
      interface GameResultProps {
        score: number;
        percentile?: number; // percentile이 선택 속성이라, undefined일 수 있기 때문에 and 연산자가 필요했음
        reStart: () => void;
      }
    ```

3. 왜 선택 속성으로 만들었냐
  
    레거시 코드의 변경 사항에서 눈치 채셨겠지만?
    예전에는 게임 종료 API 연결 전이어서 넘길 `percentile` 값이 없었음 = percentile을 잠시 선택 속성으로...
    근데 서버에서는 percentile 값을 항상 주는데, 레거시 코드를 위해 선택 속성으로 해둔다면
    나중에 헷갈릴 수 있을 거 같아 필수 속성으로 바꿨습니당