### PR TITLE
refactor: z-index를 tailwind.config 파일에서 관리하도록 수정

### DIFF
--- a/src/components/BottomNav/BottomNav.tsx
+++ b/src/components/BottomNav/BottomNav.tsx
@@ -11,7 +11,7 @@ export const BottomNav = () => {
   const location = useLocation().pathname;
 
   return (
-    <div className="sticky bottom-0 z-[999] flex w-full justify-center">
+    <div className="z-bottomNav sticky bottom-0 flex w-full justify-center">
       <div className="flex h-16 w-full max-w-3xl items-center justify-around rounded-t-2xl bg-primary-light text-gray-500 shadow-navigation">
         <RouterLink
           to={PATH.SNACK_GAME}

--- a/src/components/DropDown/DropDown.tsx
+++ b/src/components/DropDown/DropDown.tsx
@@ -45,7 +45,7 @@ export default function Dropdown({
         </motion.div>
       </div>
       {isOpen && (
-        <div className="absolute z-10 mt-1 min-w-[150px] divide-y-2 rounded-md border-2 border-primary bg-white">
+        <div className="z-dropDown absolute mt-1 min-w-[150px] divide-y-2 rounded-md border-2 border-primary bg-white">
           {options.map((option) => (
             <motion.div
               key={option.name}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -57,7 +57,9 @@ const Header = ({ children, className }: HeaderProps) => {
   };
 
   return (
-    <header className={twMerge('z-50 w-full bg-white shadow-md', className)}>
+    <header
+      className={twMerge('z-header w-full bg-white shadow-md', className)}
+    >
       <div className="container relative mx-auto flex max-w-7xl flex-col items-center justify-between p-4 lg:flex-row lg:justify-between xl:px-0">
         <div className={'flex w-full items-center justify-between lg:flex-1'}>
           <RouterLink to={'/'} hover={false}>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -34,7 +34,7 @@ const Modal = () => {
     <>
       {open && (
         <div
-          className={'fixed top-0 z-50 h-screen w-screen bg-gray-500/50'}
+          className={'z-modal fixed top-0 h-screen w-screen bg-gray-500/50'}
           onClick={handleClose}
         >
           <motion.div

--- a/src/components/SnackRain/SnackRainContainer.tsx
+++ b/src/components/SnackRain/SnackRainContainer.tsx
@@ -8,7 +8,7 @@ const SnackRainContainer = () => {
   return (
     <div
       ref={canvasBaseRef}
-      className={'absolute left-0 top-0 -z-50 h-full w-full bg-game'}
+      className={'z-snackRain absolute left-0 top-0 h-full w-full bg-game'}
     >
       <SnackRain offsetWidth={offsetWidth} offsetHeight={offsetHeight} />
     </div>

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -23,12 +23,12 @@ const TopBar = ({ title, backUrl }: { title: string; backUrl: string }) => {
   return (
     <>
       <div className="fixed top-0 flex h-12 w-screen items-center justify-between border-b-[1px] border-gray-200 bg-primary-light">
-        <RouterLink to={backUrl} className="z-10 ml-4">
-          <DownArrow className="h-8 w-8 rotate-90 text-black" />
-        </RouterLink>
         <p className="absolute w-full text-center text-lg font-semibold">
           {title}
         </p>
+        <RouterLink to={backUrl} className="ml-4">
+          <DownArrow className="h-8 w-8 rotate-90 text-black" />
+        </RouterLink>
       </div>
       <Spacing size={3} />
     </>

--- a/src/pages/user/components/ExpChart.tsx
+++ b/src/pages/user/components/ExpChart.tsx
@@ -40,7 +40,7 @@ const ExpChart = ({ status }: { status: StatusType }) => {
     <div className="flex h-44 w-44 justify-center">
       <Doughnut data={data} options={options} />
       <div
-        className={`absolute bottom-[-16px] z-10 flex h-10 w-10 items-center justify-center rounded-full text-xl text-white drop-shadow`}
+        className={`z-levelBadge absolute bottom-[-16px] flex h-10 w-10 items-center justify-center rounded-full text-xl text-white drop-shadow`}
         style={{ backgroundColor: TIER_COLOR[tier] }}
       >
         {level}

--- a/src/pages/user/components/UserInfo.tsx
+++ b/src/pages/user/components/UserInfo.tsx
@@ -29,7 +29,7 @@ const UserInfo = () => {
   return (
     <div className="relative mt-20 h-full pt-20">
       <RouterLink to={PATH.SETTING}>
-        <SettingIcon className="absolute right-0 top-12 z-10 mr-2" />
+        <SettingIcon className="absolute right-0 top-12 mr-2" />
       </RouterLink>
       <div className={'flex min-h-full flex-col items-center bg-game pb-20'}>
         {profile && (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,6 +23,15 @@ export default {
         navigation:
           '0px 0px 4px 0px rgba(0, 0, 0, 0.4), 2px 4px 12px 0px rgba(0, 0, 0, 0.1)',
       },
+
+      zIndex: {
+        snackRain: -1,
+        dropDown: 1,
+        header: 1,
+        levelBadge: 1,
+        bottomNav: 999,
+        modal: 1000,
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 💻 개요

- 리팩토링 & 이슈 대응
- #257 

## 📋 변경 및 추가 사항

- bottom nav보다 modal이 더 위에 뜨도록 z-index를 수정했습니다

- 관리하기 편하게 z-index를 tailwind.config 파일에 커스터마이징 해서 사용하는 방식으로 수정했습니다

  - 굳이 z-index를 쓰지 않아도 되는데 쓰는 부분 수정

  - `-1`, `1` 쓰다가 갑자기 `999`로 급발진 하는 이유
    
     작은 숫자는 주변 요소와의 z-index만 조절하면 되는 경우!
     근데 BottomNav, Modal 같이 여러 곳에서 쓰일 수 있는 컴포넌트는 아예 크게 해두는게
     나중에 z-index 가진 요소를 추가하기 편할 거 같다는 띵킹

![image](https://github.com/user-attachments/assets/f5638e1e-048d-49d2-bf88-aa54d38ab880)
