### PR TITLE
feat: 앱에 토큰 재발급을 위임할 수 있다

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -38,7 +38,7 @@ api.interceptors.response.use(
         originalRequest._renewal === true &&
         status === 401 &&
         (code === 'REFRESH_TOKEN_EXPIRED_EXCEPTION' ||
-          code === 'TOKEN_UNRESOLVABLE')
+          code === 'TOKEN_UNRESOLVABLE_EXCEPTION')
       ) {
         await authApi.logOut();
         window.dispatchEvent(new Event('loggedOut'));

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -29,6 +29,7 @@ api.interceptors.response.use(
           }
         } catch (error) {
           await authApi.logOut();
+          localStorage.clear();
           window.dispatchEvent(new Event('loggedOut'));
           window.location.href = PATH.MAIN;
         }
@@ -41,6 +42,7 @@ api.interceptors.response.use(
           code === 'TOKEN_UNRESOLVABLE_EXCEPTION')
       ) {
         await authApi.logOut();
+        localStorage.clear();
         window.dispatchEvent(new Event('loggedOut'));
         window.location.href = PATH.MAIN;
       }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -73,7 +73,7 @@ function appRefresh(): Promise<void> {
 
     const cleanup = () => {
       window.removeEventListener('app-refreshed', successHandler);
-      window.removeEventListener('app-refresh-failed', successHandler);
+      window.removeEventListener('app-refresh-failed', failureHandler);
       clearTimeout(timeout);
     };
   });


### PR DESCRIPTION
## 💻 개요

서비스 사용중 토큰 만료 + 재발급이 발생한 경우를 대응합니다.
현재 웹에서는 interceptor를 통해 재발급하고 있는데요, 덕분에 앱의 WebView에서도 1주일 이상 로그인이 잘 유지됩니다.
그러나 앱 재실행 시 문제가 생기는데요.
앱 입장에서는 WebView 내부적으로 바뀐 쿠키를 알 수있는 방법이 마땅치 않습니다.
그래서 오랜만에 앱을 재실행하면 로그인이 풀립니다.
<img src="https://github.com/user-attachments/assets/0eaad50a-0e7d-47ec-97db-37ae45fe3379" width="700">

이에 이벤트 기반으로 interceptor의 동작을 일부 위임하고자 합니다.
<img src="https://github.com/user-attachments/assets/ab29b7ae-df2b-40de-93ee-46d50253b656" width="400">

## 📋 변경 및 추가 사항
### UserAgent가 `SnackgameApp/x.x` 인 경우
- 앱에 토큰 재발급을 요청하고, 앱의 토큰 재발급 + 쿠키 삽입 처리가 완료되면 원본 요청을 다시 시도합니다.
- 앱의 재발급 처리를 기다리는 최대 시간은 5초입니다.
- 앱이 시간 안에 처리하지 못하면 웹이 로그아웃되고, 이어서 앱도 로그아웃됩니다.

### 그 외(일반 웹)의 경우
이번 변경의 영향을 받지 않고, 기존과 동일합니다.

## 💬 To. 리뷰어
점점 스낵게임 전용 브라우저 만들기가 되어가네요 ㅋㅋ
하지만 앱과 웹을 동시에 운영하기는 쉽지 않기 때문에,,, 이게 맞다고 생각합니다.