### PR TITLE
refactor: 랭킹 페이지 UI 수정

### DIFF
--- a/src/pages/games/SnackGame/ranking/components/OtherRanking.tsx
+++ b/src/pages/games/SnackGame/ranking/components/OtherRanking.tsx
@@ -16,9 +16,9 @@ const OtherRanking = ({ otherRanking }: OtherRankingProps) => {
     <table className={'mx-auto mt-10 w-full table-fixed lg:mt-24 lg:w-[80%]'}>
       <thead className={'h-10 bg-primary text-primary-light'}>
         <tr>
-          <th>#</th>
-          <th className={'w-[40%]'}>{t('name_column')}</th>
-          <th className={'w-[30%]'}>{t('score_column')}</th>
+          <th className={'w-[20%]'}>#</th>
+          <th>{t('name_column')}</th>
+          <th className={'w-[20%]'}>{t('score_column')}</th>
         </tr>
       </thead>
       <motion.tbody>

--- a/src/pages/games/SnackGame/ranking/components/TopRanking.tsx
+++ b/src/pages/games/SnackGame/ranking/components/TopRanking.tsx
@@ -33,7 +33,7 @@ const TopRanking = ({ topRanking }: TopRankingProps) => {
         return (
           <div
             key={`top-rank-${top.owner.name}`}
-            className={`flex flex-col items-center gap-4 font-semibold text-primary-deep-dark
+            className={`flex flex-1 flex-col items-center gap-4 font-semibold text-primary-deep-dark
             ${index == 0 && 'order-2 -mt-12'}
             ${index == 1 && 'order-1'}
             ${index == 2 && 'order-3'}`}
@@ -50,7 +50,9 @@ const TopRanking = ({ topRanking }: TopRankingProps) => {
                     {top.owner.group.name}
                   </span>
                 )}
-                <span className={'text-xl text-primary'}>{top.owner.name}</span>
+                <span className={'text-center text-xl text-primary'}>
+                  {top.owner.name}
+                </span>
                 {top.owner.status?.level !== undefined && (
                   <Level level={top.owner.status.level} />
                 )}

--- a/src/pages/games/SnackGame/ranking/components/UserRanking.tsx
+++ b/src/pages/games/SnackGame/ranking/components/UserRanking.tsx
@@ -22,7 +22,7 @@ const UserRanking = ({ season, gameId }: GameSeasonProps) => {
   return (
     <>
       {userRanking && (
-        <div className="m-auto mb-20 mt-8 w-[90%] rounded-full border-2 border-primary bg-primary-light px-6 py-3 text-primary-deep-dark lg:w-1/3">
+        <div className="m-auto mb-20 mt-8 w-[90%] rounded-full border-2 border-primary bg-primary-light px-6 py-3 text-primary-deep-dark lg:w-1/2">
           <div className="flex h-full w-full items-center justify-around">
             <div className="flex flex-col">
               <div className="text-xs">{userRanking?.owner.group?.name}</div>


### PR DESCRIPTION
## 💻 개요

- 리팩토링
- #263

## 📋 변경 및 추가 사항

- 1,2,3위 콘텐츠가 동일한 너비를 차지하게 수정했습니다

  - 닉네임 길이가 길 때, 특정 순위의 너비가 길어지는 현상을 방지
    (대신 닉네임이 여러줄로 보일 수 있어 텍스트 중앙 정렬도 추가)

- `OtherRanking` 테이블 열의 너비 비율을 수정했습니다

  - 닉네임의 최대 길이를 생각했을 때 닉네임 칸이 좁아서 쪼끔 늘렸습니다
  - 등수는 최대 2자리, 점수는 최대 3자리까지 들어갈테니 너비를 줄여도 큰 문제가 없다 생각했어용

- 화면 사이즈가 `lg`일 때 `UserRanking`의 너비를 1/3 -> 1/2로 늘렸습니다

  - 여기도 닉네임 최대 길이를 생각했을 때 약간,, 더 길면 좋겠다 싶어서 슬쩍.

| before | after | 
|:---:|:---:|
|![image](https://github.com/user-attachments/assets/b6885bdf-99e2-43c8-ada5-50f7c00e8712)|![image](https://github.com/user-attachments/assets/fbd7897a-458d-4200-a6a2-6cf8795c6203)|


## 💬 To. 리뷰어
이거 올리고 바로 지금 열린 PR 리뷰하러 가겠습니닥!!!!!!!!!!!!!!!