### PR TITLE
fix(BottomNav): BottomNav가 스크롤되는 문제

### DIFF
--- a/src/components/BottomNav/BottomNav.tsx
+++ b/src/components/BottomNav/BottomNav.tsx
@@ -11,7 +11,7 @@ export const BottomNav = () => {
   const location = useLocation().pathname;
 
   return (
-    <div className="z-bottomNav sticky bottom-0 flex w-full justify-center">
+    <div className="fixed bottom-0 z-bottomNav flex w-full justify-center">
       <div className="flex h-16 w-full max-w-3xl items-center justify-around rounded-t-2xl bg-primary-light text-gray-500 shadow-navigation">
         <RouterLink
           to={PATH.SNACK_GAME}

--- a/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
+++ b/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
@@ -31,7 +31,7 @@ const RankingSection = ({ season, gameId }: GameSeasonProps) => {
 
   if (totalRanking.length === 0) return <EmptyRanking />;
   return (
-    <div className={'mx-auto w-full max-w-4xl'}>
+    <div className={'mx-auto w-full max-w-4xl mb-16'}>
       {userInfo.type && userInfo.type !== 'GUEST' && (
         <UserRanking season={season} gameId={gameId} />
       )}


### PR DESCRIPTION
## 💻 개요
- resolves: #266 
BottomNav가 스크롤과 함께 오르락 내리락하는 문제를 해결합니다.

## 📋 변경 및 추가 사항

BottomNav의 position을 fixed로 복구하고, 랭킹 페이지 하단에 BottomNav 높이만큼(`mb-16`, `4rem`) 마진을 주었습니다.

## 💬 To. 리뷰어
일단은 임시방편.. 레이아웃 재구성을 고민해봐야할 것 같기도 합니다.