### PR TITLE
fix: 게스트의 랭킹 페이지가 잘못 그려지는 문제

### DIFF
--- a/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
+++ b/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 
 import LogoImage from '@assets/images/main.png';
+import Spacing from '@components/Spacing/Spacing';
 import OtherRanking from '@pages/games/SnackGame/ranking/components/OtherRanking';
 import TopRanking from '@pages/games/SnackGame/ranking/components/TopRanking';
 import { userState } from '@utils/atoms/member.atom';
@@ -31,9 +32,11 @@ const RankingSection = ({ season, gameId }: GameSeasonProps) => {
 
   if (totalRanking.length === 0) return <EmptyRanking />;
   return (
-    <div className={'mx-auto w-full max-w-4xl mb-16'}>
-      {userInfo.type && userInfo.type !== 'GUEST' && (
+    <div className={'mx-auto mb-16 w-full max-w-4xl'}>
+      {userInfo.type && userInfo.type !== 'GUEST' ? (
         <UserRanking season={season} gameId={gameId} />
+      ) : (
+        <Spacing size={5} />
       )}
       {topRanking && <TopRanking topRanking={topRanking} />}
       {otherRanking && <OtherRanking otherRanking={otherRanking} />}


### PR DESCRIPTION
## 💻 개요

- 이슈 대응
- #268

## 📋 변경 및 추가 사항

- 게스트 유저일 때 `UserRanking` 컴포넌트를 렌더링 하지 않기 때문에,

  `DropDown`과 `TopRanking` 사이 여백 보장을 위해 `Spacing` 컴포넌트를 삽입했습니다

  ![랭킹](https://github.com/user-attachments/assets/f886cf04-a047-4c1c-811c-ac00cf9fa2eb)
