### PR TITLE
fix(GameResult): 앱은 사용자 통합 API를 호출하지 않는다

### DIFF
--- a/src/pages/games/SnackGame/game/legacy/components/GameResult.tsx
+++ b/src/pages/games/SnackGame/game/legacy/components/GameResult.tsx
@@ -11,6 +11,8 @@ import {
 import useModal from '@hooks/useModal';
 
 import ExpBarChart from './ExpBarChart';
+import { isApp } from '@utils/userAgentIdentifier';
+import membersApi from '@api/members.api';
 
 interface GameResultProps {
   score: number;
@@ -30,6 +32,9 @@ const GameResult = ({ score, percentile, reStart }: GameResultProps) => {
   };
 
   const onOAuthSuccess = async () => {
+    if (isApp()) {
+      return await membersApi.getMemberProfile();
+    }
     return await integrateMember.mutateAsync();
   };
 


### PR DESCRIPTION
## 📋 변경 및 추가 사항
`GameResult` 창에서 소셜 로그인을 할 때, 앱에서는 integrateMember를 호출하지 않게 했습니다.

## 💬 To. 리뷰어
변경사항 공유를 하나 깜빡했네요.
OIDC를 사용하면 기존처럼 소셜 로그인을 1. OAuth 과정, 2. 서비스 로그인으로 분리할 필요가 없습니다.
이 점을 활용해 OIDC 로그인 시 게스트 계정을 새 계정으로 자동 통합하도록 로직을 작성했는데요.
- https://github.com/snack-game/server/pull/158
<img width="452" alt="image" src="https://github.com/user-attachments/assets/db10b627-b5be-4688-9a4b-20d37dcfb62c">

웹도 OIDC 기반으로 옮겨가면서 이걸 활용해 회원가입/전환 로직 부담을 좀 덜어내면 어떨까요?