### PR TITLE
fix(SnackgameBase): 게임 종료 시 자신의 랭킹을 새로 받아와야 한다

### DIFF
--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useRef } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 
 import { pixiState } from '@utils/atoms/game.atom';
 import { userState } from '@utils/atoms/member.atom';
 
+import { QUERY_KEY } from '@constants/api.constant';
 import { useGuest } from '@hooks/queries/auth.query';
 import useModal from '@hooks/useModal';
 
@@ -35,6 +37,7 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
   const pixiValue = useRecoilValue(pixiState);
   const userInfo = useRecoilValue(userState);
   const guestMutation = useGuest();
+  const queryClient = useQueryClient();
 
   // TODO: 훅 안으로 끌고 들어가기
   const initializeAppScreens = async (application: SnackgameApplication) => {
@@ -110,6 +113,9 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
 
   const handleGameEnd = async () => {
     const data = await gameEnd(session!.sessionId);
+    queryClient.invalidateQueries({
+      queryKey: [QUERY_KEY.USER_RANKING, QUERY_KEY.SEASON_USER_RANKING],
+    });
 
     openModal({
       children: (

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -100,7 +100,7 @@ export class GameScreen extends Container implements AppScreen {
     const snackGameConfig = snackGameGetConfig({
       rows: 8,
       columns: 6,
-      duration: 120,
+      duration: 30,
       mode,
     });
 

--- a/src/pages/games/SnackGame/ranking/components/UserRanking.tsx
+++ b/src/pages/games/SnackGame/ranking/components/UserRanking.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
 import { Level } from '@components/Level/Level';
+import Spacing from '@components/Spacing/Spacing';
 import { GameSeasonProps } from '@utils/types/common.type';
 
 import {
@@ -21,7 +22,7 @@ const UserRanking = ({ season, gameId }: GameSeasonProps) => {
 
   return (
     <>
-      {userRanking && (
+      {userRanking ? (
         <div className="m-auto mb-20 mt-8 w-[90%] rounded-full border-2 border-primary bg-primary-light px-6 py-3 text-primary-deep-dark lg:w-1/2">
           <div className="flex h-full w-full items-center justify-around">
             <div className="flex flex-col">
@@ -41,6 +42,8 @@ const UserRanking = ({ season, gameId }: GameSeasonProps) => {
             </div>
           </div>
         </div>
+      ) : (
+        <Spacing size={5} />
       )}
     </>
   );


### PR DESCRIPTION
## 💻 개요
<img src="https://github.com/user-attachments/assets/aa0d2bd6-3423-426e-9431-401d50ddb9f6" width="400">

이 화면에 문제가 2가지 있는데요.
하나는 자신의 랭킹이 있음에도 (6위, 39점) 표시되지 않는다는 것.
하나는 아직 랭킹이 없는 상황에서 1등이 너무 높이 있다는 것입니다.

## 📋 변경 및 추가 사항
- 게임 종료 시 query를 invalidate하게 변경했습니다. 
  이 상태에서 랭킹 페이지 접근 시 자신의 랭킹을 새로 받아오게 됩니다.
- 자신의 랭킹이 아직 없는 경우 공백을 표시합니다. (`<Spacing size={5} />`)

## 💬 To. 리뷰어
Q. 쿼리 invalidation을 이렇게 직접 다뤄줘야 할까요? 아직 '쿼리'로 묶이지 않아서 불편한거겠죠?