### PR TITLE
fix: 그룹이 없는 경우 프로필 수정이 불가한 문제

### DIFF
--- a/src/api/groups.api.ts
+++ b/src/api/groups.api.ts
@@ -11,7 +11,9 @@ export const getGroupsNames = async (startWith: string) => {
   return data;
 };
 
-export const changeGroupName = async (group: string): Promise<MemberType> => {
+export const changeGroupName = async (
+  group: string | null,
+): Promise<MemberType> => {
   const { data } = await api.put('members/me/group', {
     group,
   });

--- a/src/constants/regexp.constant.ts
+++ b/src/constants/regexp.constant.ts
@@ -1,3 +1,3 @@
 export const NAME_REGEXP = /^[a-zA-Z가-힣0-9-_]{2,}$/;
 export const GROUP_REGEXP = /^$|^[가-힣A-Za-z0-9-_]{2,}$/;
-export const GROUP_CHANGE_REGEXP = /^[가-힣A-Za-z0-9-_]{2,}$/;
+export const GROUP_CHANGE_REGEXP = /^[가-힣A-Za-z0-9-_]{0,}$/;

--- a/src/constants/regexp.constant.ts
+++ b/src/constants/regexp.constant.ts
@@ -1,3 +1,3 @@
 export const NAME_REGEXP = /^[a-zA-Z가-힣0-9-_]{2,}$/;
 export const GROUP_REGEXP = /^$|^[가-힣A-Za-z0-9-_]{2,}$/;
-export const GROUP_CHANGE_REGEXP = /^[가-힣A-Za-z0-9-_]{0,}$/;
+export const GROUP_CHANGE_REGEXP = /^[가-힣A-Za-z0-9-_]{2,}$/;

--- a/src/hooks/queries/members.query.ts
+++ b/src/hooks/queries/members.query.ts
@@ -70,7 +70,6 @@ export const useGetMemberProfile = () => {
   const { data } = useSuspenseQuery({
     queryKey: [QUERY_KEY.USER_PROFILE],
     queryFn: getMemberProfile,
-    gcTime: 0,
   });
 
   return data;

--- a/src/hooks/queries/members.query.ts
+++ b/src/hooks/queries/members.query.ts
@@ -70,6 +70,7 @@ export const useGetMemberProfile = () => {
   const { data } = useSuspenseQuery({
     queryKey: [QUERY_KEY.USER_PROFILE],
     queryFn: getMemberProfile,
+    gcTime: 0,
   });
 
   return data;

--- a/src/hooks/queries/members.query.ts
+++ b/src/hooks/queries/members.query.ts
@@ -67,12 +67,10 @@ export const useIntegrateMember = () => {
 };
 
 export const useGetMemberProfile = () => {
-  const { data } = useSuspenseQuery({
+  return useSuspenseQuery({
     queryKey: [QUERY_KEY.USER_PROFILE],
     queryFn: getMemberProfile,
   });
-
-  return data;
 };
 
 export const useDeleteMember = () => {

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -2,7 +2,7 @@ import { ChangeEvent, useState } from 'react';
 
 interface useInputProps<T> {
   initialValue: T;
-  isInvalid?: (value: T) => boolean;
+  isValid?: (value: T) => boolean;
 }
 
 export interface useInputResult<T> {
@@ -14,18 +14,18 @@ export interface useInputResult<T> {
 
 const useInput = <T>({
   initialValue,
-  isInvalid,
+  isValid,
 }: useInputProps<T>): useInputResult<T> => {
   const [valid, setValid] = useState<boolean>(
-    isInvalid ? isInvalid(initialValue) : true,
+    isValid ? isValid(initialValue) : true,
   );
   const [value, setValue] = useState(initialValue);
 
   const handleChangeValue = (event: ChangeEvent<HTMLInputElement>): void => {
     const eventValue = event.target.value as T;
 
-    if (isInvalid) {
-      setValid(isInvalid(eventValue));
+    if (isValid) {
+      setValid(isValid(eventValue));
     }
 
     setValue(eventValue);

--- a/src/pages/games/SnackGame/game/legacy/components/GameResult.tsx
+++ b/src/pages/games/SnackGame/game/legacy/components/GameResult.tsx
@@ -21,7 +21,7 @@ interface GameResultProps {
 }
 
 const GameResult = ({ score, percentile, reStart }: GameResultProps) => {
-  const profile = useGetMemberProfile();
+  const { data: profile } = useGetMemberProfile();
   const userStateValue = useRecoilValue(userState);
   const integrateMember = useIntegrateMember();
   const { closeModal } = useModal();

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -39,12 +39,12 @@ const ProfileSection = ({
 
   const newName = useInput<string>({
     initialValue: profile.name || '',
-    isInvalid: (name) => NAME_REGEXP.test(name),
+    isValid: (name) => NAME_REGEXP.test(name),
   });
 
   const newGroup = useInput<string>({
     initialValue: profile.group?.name || '',
-    isInvalid: (group) => (group ? GROUP_CHANGE_REGEXP.test(group) : true),
+    isValid: (group) => (group ? GROUP_CHANGE_REGEXP.test(group) : true),
   });
 
   const setUserState = useSetRecoilState(userState);

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -44,7 +44,7 @@ const ProfileSection = ({
 
   const newGroup = useInput<string>({
     initialValue: profile.group?.name || '',
-    isValid: (group) => (group ? GROUP_CHANGE_REGEXP.test(group) : true),
+    isValid: (group) => GROUP_CHANGE_REGEXP.test(group),
   });
 
   const setUserState = useSetRecoilState(userState);
@@ -67,8 +67,8 @@ const ProfileSection = ({
     if (profile.name !== newName.value) {
       newProfile = await changeUserName.mutateAsync(newName.value);
     }
-    if (newGroup.value && profile.group?.name !== newGroup.value) {
-      newProfile = await changeGroupName.mutateAsync(newGroup.value);
+    if (profile.group && profile.group.name !== newGroup.value) {
+      newProfile = await changeGroupName.mutateAsync(newGroup.value || null);
     }
     if (newImageFile !== null) {
       newProfile = await changeUserImage.mutateAsync(newImageFile);

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -44,7 +44,7 @@ const ProfileSection = ({
 
   const newGroup = useInput<string>({
     initialValue: profile.group?.name || '',
-    isValid: (group) => GROUP_CHANGE_REGEXP.test(group),
+    isValid: (group) => (group ? GROUP_CHANGE_REGEXP.test(group) : true),
   });
 
   const setUserState = useSetRecoilState(userState);
@@ -67,7 +67,8 @@ const ProfileSection = ({
     if (profile.name !== newName.value) {
       newProfile = await changeUserName.mutateAsync(newName.value);
     }
-    if (profile.group && profile.group.name !== newGroup.value) {
+    if (profile.group?.name !== newGroup.value) {
+      if (profile.group === null && newGroup.value === '') return;
       newProfile = await changeGroupName.mutateAsync(newGroup.value || null);
     }
     if (newImageFile !== null) {

--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -44,7 +44,7 @@ const ProfileSection = ({
 
   const newGroup = useInput<string>({
     initialValue: profile.group?.name || '',
-    isInvalid: (group) => GROUP_CHANGE_REGEXP.test(group),
+    isInvalid: (group) => (group ? GROUP_CHANGE_REGEXP.test(group) : true),
   });
 
   const setUserState = useSetRecoilState(userState);
@@ -67,7 +67,7 @@ const ProfileSection = ({
     if (profile.name !== newName.value) {
       newProfile = await changeUserName.mutateAsync(newName.value);
     }
-    if (profile.group?.name !== newGroup.value) {
+    if (newGroup.value && profile.group?.name !== newGroup.value) {
       newProfile = await changeGroupName.mutateAsync(newGroup.value);
     }
     if (newImageFile !== null) {

--- a/src/pages/user/components/UserInfo.tsx
+++ b/src/pages/user/components/UserInfo.tsx
@@ -11,7 +11,7 @@ import PATH from '@constants/path.constant';
 import { useGetMemberProfile } from '@hooks/queries/members.query';
 
 const UserInfo = () => {
-  const profile = useGetMemberProfile();
+  const { data: profile, isFetching } = useGetMemberProfile();
   const [isEditing, setIsEditing] = useState(false);
 
   const handleClickEdit = () => {
@@ -32,7 +32,7 @@ const UserInfo = () => {
         <SettingIcon className="absolute right-0 top-12 mr-2" />
       </RouterLink>
       <div className={'flex min-h-full flex-col items-center bg-game pb-20'}>
-        {profile && (
+        {!isFetching && (
           <ProfileSection
             profile={profile}
             isEditing={isEditing}


### PR DESCRIPTION
## 💻 개요

- 이슈대응
- #288

## 📋 변경 및 추가 사항

### 1. 그룹이 "원래" 없던 사용자의 프로필 수정이 불가했던 문제

#### 입력한 그룹 값이 없는데 에러 메시지가 왜 뜨냐

1. 그룹이 없는 경우 서버 응답의 `group` = null ➡️ 이는 `newGroup.value = ''`으로 초기화
2. 공백은 `GROUP_CHANGE_REGEXP` 정규식에 어긋나 invalid한 값으로 판단

    ![image](https://github.com/user-attachments/assets/0e8b51f0-6624-46cc-bf90-bc86f84ad163)

#### 를 이렇게 수정했습니다

1. 그룹이 공백인 경우 정규식을 거치지 않고 valid한 값으로 판단하도록 합니다

![profile](https://github.com/user-attachments/assets/67caa585-27d3-4be8-874c-170b5abb96a1)

> 💫 닉네임만 바꿨을 때 프로필 수정이 가능한 점 -> 이후 그룹 설정도 되는 점에 집중해서 봐주시면 됩니다!!

### 2. 계정을 바꿔서 로그인 했을 때 이전 계정 정보가 노출되는 문제

해당 부분에 코멘트로 서술했습니다!

### 3. 그룹 수정 API 변경 (그룹 탈퇴) 대응

해당 부분에 코멘트로 서술했습니다!!

## 💬 To. 리뷰어

그근데
한번 그룹에 가입하면 탈퇴는 안되는 거네요...?!
나중에 그룹 이름을 공백으로 보내면 탈퇴 처리한다 ⬅️ 요런 기능도 계획에 있나요??