### PR TITLE
chore: 게임 시간 30초 -> 120초로 돌려놓기

### DIFF
--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -100,7 +100,7 @@ export class GameScreen extends Container implements AppScreen {
     const snackGameConfig = snackGameGetConfig({
       rows: 8,
       columns: 6,
-      duration: 30,
+      duration: 120,
       mode,
     });
 


### PR DESCRIPTION
## 💻 개요

- 소공전을 위해 임의 수정했던 시간!!! 다시 돌려놓기

## 📋 변경 및 추가 사항

- 저번에 30초로 수정해놨던 커밋 revert 했읍니다 (빌드 테스트 끗나면 바로 머지할게용)
