### PR TITLE
fix: 그룹이 없으면 이미지 수정이 안되는 문제

### DIFF
--- a/src/pages/user/components/ProfileSection.tsx
+++ b/src/pages/user/components/ProfileSection.tsx
@@ -79,16 +79,16 @@ const ProfileSection = ({
   const handleProfileChange = async () => {
     let newProfile = undefined;
 
+    if (newImageFile !== null) {
+      newProfile = await changeUserImage.mutateAsync(newImageFile);
+      setNewImageFile(null);
+    }
     if (profile.name !== newName.value) {
       newProfile = await changeUserName.mutateAsync(newName.value);
     }
     if (profile.group?.name !== newGroup.value) {
-      if (profile.group === null && newGroup.value === '') return;
+      if (profile.group === null && newGroup.value === '') return newProfile;
       newProfile = await changeGroupName.mutateAsync(newGroup.value || null);
-    }
-    if (newImageFile !== null) {
-      newProfile = await changeUserImage.mutateAsync(newImageFile);
-      setNewImageFile(null);
     }
 
     return newProfile;


### PR DESCRIPTION
## 💻 개요

- 이슈 대응
- #294 

## 📋 변경 및 추가 사항

- 이름/그룹/이미지 순으로 수정 요청 보내던 순서를 수정 (이미지/이름/그룹)
- 그룹 가입이 안된 상태에서 && 그룹 수정이 없을 경우 `return undefined` ➡ `return newProfile`로 수정

- 이미지 수정이 안됐던 이유

  - 문제가 발생하던 상황 (그룹 없고 그룹 수정도 없음)
  - `return;` 을 넣어둔 탓에
  - 그룹 수정 아래 있던 이미지 수정 조건문은 알 바 아니고.... 함수를 바로 탈출.... 해버림


## 💬 To. 리뷰어

땡스투 손모양...........
그리고 그룹 없을 때 안된다고 발견해준 땡칠에게 박수. 보냅니다

이미지 압축 및 변환 (heif) 작업은 별도의 브랜치에서 진행할게요~~~! 까먹은 거 아님