### PR TITLE
fix: Modal 높이가 콘텐츠가 비해 짧은 문제

### DIFF
--- a/src/components/Auth/OAuth.tsx
+++ b/src/components/Auth/OAuth.tsx
@@ -106,7 +106,7 @@ const OAuth = ({ oAuthOnSuccess }: OAuthContainerProps) => {
   }, []);
 
   return (
-    <div className={'flex h-full flex-col items-center justify-evenly'}>
+    <div className={'flex flex-grow flex-col items-center justify-evenly'}>
       <div className={'flex w-full flex-col items-center gap-4'}>
         <span className={'font-semibold text-primary'}>{t('what_rank')}</span>
         <div

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -34,12 +34,12 @@ const Modal = () => {
     <>
       {open && (
         <div
-          className={'z-modal fixed top-0 h-screen w-screen bg-gray-500/50'}
+          className={'fixed top-0 z-modal h-screen w-screen bg-gray-500/50'}
           onClick={handleClose}
         >
           <motion.div
             className={
-              'absolute left-1/2 top-1/2 h-1/2 w-[80%] min-w-fit rounded-xl bg-white p-10 shadow-md lg:max-h-[600px] lg:w-1/4 lg:max-w-[400px]'
+              'absolute left-1/2 top-1/2 flex min-h-[50%] w-[80%] min-w-fit flex-col rounded-xl bg-white p-10 shadow-md lg:max-h-[600px] lg:w-1/4 lg:max-w-[400px]'
             }
             onClick={(event) => event.stopPropagation()}
             initial={{ y: 10, opacity: 0, x: '-50%' }}

--- a/src/pages/games/SnackGame/game/legacy/components/GameResult.tsx
+++ b/src/pages/games/SnackGame/game/legacy/components/GameResult.tsx
@@ -39,7 +39,7 @@ const GameResult = ({ score, percentile, reStart }: GameResultProps) => {
   };
 
   return (
-    <div className={'flex h-full w-full flex-col justify-evenly'}>
+    <div className={'flex w-full flex-grow flex-col justify-evenly gap-4'}>
       <div className={'mx-auto flex flex-col items-center gap-4 font-semibold'}>
         <p className="text-6xl text-primary">{score}점</p>
 


### PR DESCRIPTION
## 💻 개요

- 이슈 대응
- #296 

## 📋 변경 및 추가 사항

- `Modal`의 높이가 부족해서 생기는 문제여서 `h-1/2`를 `min-h-[50%]`로 수정했습니다

  - 전: 높이 50vh 고정
  - 후: 높이 **최소** 50vh & 콘텐츠에 따라 더 늘어날 수 있음

- 단, `height`를 `min-height`로 바꿀 경우 자식 요소의 `height: 100%`이 동작하지 않게 됩니다

  `height: 100%`을 사용하지 않고도 남은 높이 전부를 차지할 수 있게 `flex-grow`로 수정했어욥

![image](https://github.com/user-attachments/assets/cb4c7b2a-613b-497a-b24c-b54494c969e3)

## 💬 To. 리뷰어

주말 중에 안드로이드 테스트 쪼끔 더 해봤는데, 안드 자체의 문제는 더 발견 못해서
일단 심사 한번 제출해도 될 거 같습니다............!!
