### PR TITLE
fix(GameEffect): 게임 재시작 시 스낵이 사라지는 문제를 해소한다

### DIFF
--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -131,7 +131,6 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
 
   const navigateToLobby = async () => {
     session = undefined;
-    application.dismissPopup();
     application.show(LobbyScreen);
   };
 

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -196,8 +196,7 @@ export class GameScreen extends Container implements AppScreen {
   public async onHide({ width, height }: Rectangle) {
     this.score.hide();
     this.timer.hide();
-    this.vfx?.playGridExplosion();
-    await waitFor(1);
+    await this.vfx?.playGridExplosion();
   }
 
   /** 게임 종료 시 트리거 */

--- a/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
+++ b/src/pages/games/SnackGame/game/screen/SnackgameApplication.ts
@@ -8,17 +8,16 @@ export class SnackgameApplication extends Application {
   private _currentAppScreen?: AppScreen;
   private _currentPopup?: AppScreen;
 
-  get currentAppScreen(): AppScreen | undefined {
-    return this._currentAppScreen;
-  }
   private set currentAppScreen(appScreen: AppScreen) {
     this.stage.removeChildren();
     this._currentAppScreen = appScreen;
     this.stage.addChild(appScreen);
   }
-  get currentPopup() {
-    return this._currentPopup;
+
+  private get currentAppScreen(): AppScreen | undefined {
+    return this._currentAppScreen;
   }
+
   private set currentPopup(popup: AppScreen | undefined) {
     if (this.currentPopup) {
       this.stage.removeChild(this.currentPopup);
@@ -27,6 +26,10 @@ export class SnackgameApplication extends Application {
       this.stage.addChild(popup);
     }
     this._currentPopup = popup;
+  }
+
+  private get currentPopup() {
+    return this._currentPopup;
   }
 
   constructor(
@@ -58,6 +61,7 @@ export class SnackgameApplication extends Application {
   }
 
   public async showAppScreen(appScreen: AppScreen) {
+    this.dismissPopup();
     if (this.currentAppScreen) {
       await this.hideAndReset(this.currentAppScreen);
     }

--- a/src/pages/games/SnackGame/game/ui/GameEffect.ts
+++ b/src/pages/games/SnackGame/game/ui/GameEffect.ts
@@ -76,7 +76,7 @@ export class GameEffects extends Container {
     this.addChild(snack);
     await this.playFlyToTarget(snack, { x, y });
     this.removeChild(snack);
-    pool.giveBack(Snack);
+    pool.giveBack(snack);
   }
 
   /** 게임 시작 전 스낵이 위치를 찾아가는 애니메이션 */

--- a/src/pages/games/SnackGame/game/ui/GameEffect.ts
+++ b/src/pages/games/SnackGame/game/ui/GameEffect.ts
@@ -63,7 +63,7 @@ export class GameEffects extends Container {
     const x = this.game.score.x + randomRange(-20, 20);
     const y = this.game.score.y - 55;
 
-    const snack = new Snack();
+    const snack = pool.get(Snack);
     snack.setup({
       name: data.snack.name,
       snackNum: data.snack.snackNum,
@@ -76,11 +76,12 @@ export class GameEffects extends Container {
     this.addChild(snack);
     await this.playFlyToTarget(snack, { x, y });
     this.removeChild(snack);
+    pool.giveBack(Snack);
   }
 
   /** 게임 시작 전 스낵이 위치를 찾아가는 애니메이션 */
   public async animationBeforeStart(snack: Snack) {
-    const copySnack = new Snack();
+    const copySnack = pool.get(Snack);
     copySnack.setup({
       name: snack.name,
       snackNum: snack.snackNum,
@@ -95,6 +96,7 @@ export class GameEffects extends Container {
     await this.playFlyToTarget(copySnack, this.toLocal(snack.getGlobalPosition()));
     snack.visible = true;
     this.removeChild(copySnack);
+    pool.giveBack(copySnack);
   }
 
   /** a, b 사이의 거리 계산 */

--- a/src/pages/games/SnackGame/game/ui/GameEffect.ts
+++ b/src/pages/games/SnackGame/game/ui/GameEffect.ts
@@ -63,7 +63,7 @@ export class GameEffects extends Container {
     const x = this.game.score.x + randomRange(-20, 20);
     const y = this.game.score.y - 55;
 
-    const snack = pool.get(Snack);
+    const snack = new Snack();
     snack.setup({
       name: data.snack.name,
       snackNum: data.snack.snackNum,
@@ -76,14 +76,11 @@ export class GameEffects extends Container {
     this.addChild(snack);
     await this.playFlyToTarget(snack, { x, y });
     this.removeChild(snack);
-    pool.giveBack(snack);
   }
 
   /** 게임 시작 전 스낵이 위치를 찾아가는 애니메이션 */
   public async animationBeforeStart(snack: Snack) {
-    const position = this.toLocal(snack.getGlobalPosition());
-
-    const copySnack = pool.get(Snack);
+    const copySnack = new Snack();
     copySnack.setup({
       name: snack.name,
       snackNum: snack.snackNum,
@@ -95,10 +92,9 @@ export class GameEffects extends Container {
     copySnack.position.x = this.game.score.x;
     copySnack.position.y = this.game.score.y;
     this.addChild(copySnack);
-    await this.playFlyToTarget(copySnack, { x: position.x, y: position.y });
+    await this.playFlyToTarget(copySnack, this.toLocal(snack.getGlobalPosition()));
     snack.visible = true;
     this.removeChild(copySnack);
-    pool.giveBack(copySnack);
   }
 
   /** a, b 사이의 거리 계산 */


### PR DESCRIPTION
## 💻 개요
- resolves: #280

## 📋 변경 및 추가 사항
### 스낵이 증발하는 문제를 해결합니다.
이 이슈는 해결이 어려워 보이던 이슈였는데요.
조사해보니 생각보다 너무나 간단한 문제여서 당황스럽습니다 😅
#### 원인
게임을 재시작하면 화면 전환 과정에서 스낵 제거 애니메이션이 발생합니다.
이 애니메이션의 종료를 기다리지 않고 새 게임을 시작해버렸기 때문에 발생한 문제였습니다.

<details>
<summary>상황을 자세히 말씀드려보자면... 더보기</summary>

`src/pages/games/SnackGame/game/util/pool.ts`에 MultiPool 객체가 있는데요,
스낵게임에서는 이 친구를 활용, 게임에 필요한 스낵 객체를 재사용하고 있습니다.
따라서 스낵 제거 애니메이션이 진행되고 있다면, 새 게임에서도 해당 스낵 객체를 재사용하기 때문에
게임이 시작된 상태로 스낵 제거가 이어지게 됩니다 🥲
</details>

#### 조치

화면 전환 시 스낵 제거 애니메이션을 기다리도록 하여 문제를 해결했습니다

###  화면 전환 시 팝업을 신경쓰지 않아도 됩니다
- https://github.com/snack-game/front/pull/285#discussion_r1711536550 에서 다뤘던 문제입니다

`SnackGameBase.navigateToLobby`에서 `dismissPopup()`을 직접 수행하고 있었는데, 이를 스낵게임 어플리케이션 안으로 집어넣었습니다.
이제 화면 전환 시 팝업을 신경쓰지 않아도 됩니다 :)