### PR TITLE
style: Popup 내부 함수 형식 통일 및 `connect()` 인자 수정

### DIFF
--- a/src/pages/games/SnackGame/game/popup/PausePopup.ts
+++ b/src/pages/games/SnackGame/game/popup/PausePopup.ts
@@ -43,16 +43,16 @@ export class PausePopup extends Container implements AppScreen {
     this.title.y = -80;
     this.panel.addChild(this.title);
 
-    this.endButton = new LargeButton({ text: "■", width: 90, height: 90 });
+    this.endButton = new LargeButton({ text: '■', width: 90, height: 90 });
     this.endButton.x = -100;
     this.endButton.y = 70;
-    this.endButton.onPress.connect(this.handleEndButton);
+    this.endButton.onPress.connect(this.handleEndButton.bind(this));
     this.panel.addChild(this.endButton);
 
     this.resumeButton = new LargeButton({ text: '▶', width: 200, height: 90 });
     this.resumeButton.x = 50;
     this.resumeButton.y = 70;
-    this.resumeButton.onPress.connect(this.handleResumeButton);
+    this.resumeButton.onPress.connect(this.handleResumeButton.bind(this));
     this.panel.addChild(this.resumeButton);
   }
 
@@ -60,22 +60,22 @@ export class PausePopup extends Container implements AppScreen {
     // no-op
   }
 
-  public handleEndButton = async () => {
+  public async handleEndButton() {
     try {
       await this.handleGameEnd();
     } catch (error) {
       this.app.setError(error);
     }
-  };
+  }
 
-  public handleResumeButton = async () => {
+  public async handleResumeButton() {
     try {
       await this.handleGameResume();
       this.app.dismissPopup();
     } catch (error) {
       this.app.setError(error);
     }
-  };
+  }
 
   /** 창 크기가 변경될 때마다 호출되는 팝업 크기 조정 */
   public onResize({ width, height }: Rectangle) {

--- a/src/pages/games/SnackGame/game/popup/RulePopup.ts
+++ b/src/pages/games/SnackGame/game/popup/RulePopup.ts
@@ -54,7 +54,7 @@ export class RulePopup extends Container implements AppScreen {
 
     this.doneButton = new LargeButton({ text: t('confirm', { ns: 'game' }) });
     this.doneButton.y = this.panelBase.boxHeight * 0.5 - 80;
-    this.doneButton.onPress.connect(this.handleDoneButton);
+    this.doneButton.onPress.connect(this.handleDoneButton.bind(this));
     this.panel.addChild(this.doneButton);
   }
 
@@ -62,9 +62,9 @@ export class RulePopup extends Container implements AppScreen {
     // no-op
   }
 
-  public handleDoneButton = async () => {
+  public async handleDoneButton() {
     this.app.dismissPopup();
-  };
+  }
 
   /** 창 크기가 변경될 때마다 호출되는 팝업 크기 조정 */
   public onResize({ width, height }: Rectangle) {

--- a/src/pages/games/SnackGame/game/popup/SettingPopup.ts
+++ b/src/pages/games/SnackGame/game/popup/SettingPopup.ts
@@ -38,7 +38,10 @@ export class SettingsPopup extends Container implements AppScreen {
   /** 효과음 볼륨을 변경하는 슬라이더 */
   private sfxSlider: VolumeSlider;
 
-  constructor(private app: SnackgameApplication, private handleGameResume: () => Promise<void>) {
+  constructor(
+    private app: SnackgameApplication,
+    private handleGameResume: () => Promise<void>,
+  ) {
     super();
 
     this.bg = new Sprite(Texture.WHITE); // TODO: (배경 흐리기 + 어둡게 하기)를 팝업에서 하기(bg 유지) vs 모든 팝업에 일관적으로 적용하기(bg 이동)
@@ -61,7 +64,7 @@ export class SettingsPopup extends Container implements AppScreen {
 
     this.doneButton = new LargeButton({ text: t('confirm', { ns: 'game' }) });
     this.doneButton.y = this.panelBase.boxHeight * 0.5 - 78;
-    this.doneButton.onPress.connect(this.handleDoneButton);
+    this.doneButton.onPress.connect(this.handleDoneButton.bind(this));
     this.panel.addChild(this.doneButton);
 
     this.versionLabel = new Label(
@@ -99,14 +102,14 @@ export class SettingsPopup extends Container implements AppScreen {
     this.layout.addChild(this.sfxSlider);
   }
 
-  public handleDoneButton = async () => {
+  public async handleDoneButton() {
     try {
       await this.handleGameResume();
       this.app.dismissPopup();
     } catch (error) {
       this.app.setError(error);
     }
-  };
+  }
 
   /** 창 크기가 변경될 때마다 팝업 크기 조정 */
   public onResize({ width, height }: Rectangle) {


### PR DESCRIPTION
## 💻 개요

- 리팩토링하다가 만난 이슈 대응
- #302 

## 📋 변경 및 추가 사항

- `Popup` 클래스 안에 있는 함수들을 클래스 메서드 형식으로 통일
- `connect()` 인자로 전달되는 함수는 Popup 인스턴스와 바인딩 될 수 있게 수정

![good](https://github.com/user-attachments/assets/75fa1b2f-c26c-470c-b6e4-374fe81ad3ca)

## 💬 To. 리뷰어

다음부턴 이런 앱 사용에 큰 방해가 되는 문제가 생기면 hotfix 브랜치 파서 처리할게요!!
급하다고 master에서 바로 revert 갈기지 않기....... 29483번 썼습니다 (마음으로)