### PR TITLE
feat(games): 스낵게임 Biz 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,9 @@ const MainPage = lazy(() => import('@pages/main/MainPage'));
 const SnackGamePage = lazy(
   () => import('@pages/games/SnackGame/game/SnackGamePage'),
 );
+const SnackGameBizPage = lazy(
+  () => import('@pages/games/SnackgameBiz/SnackGameBizPage'),
+);
 
 const RankingPage = lazy(
   () => import('@pages/games/SnackGame/ranking/RankingPage'),
@@ -102,6 +105,11 @@ const App = () => {
                 {/* User */}
                 <Route path={PATH.USER} element={<UserPage />} />
               </Route>
+            </Route>
+
+            <Route>
+              {/*Game*/}
+              <Route path={PATH.SNACK_GAME_BIZ} element={<SnackGameBizPage />} />
             </Route>
 
             <Route element={<PrivateRoute />}>

--- a/src/constants/path.constant.ts
+++ b/src/constants/path.constant.ts
@@ -12,6 +12,7 @@ const PATH = {
   WITHDRAW: '/user/setting/withdraw',
 
   SNACK_GAME: '/snack-game',
+  SNACK_GAME_BIZ: '/snack-game/biz',
   SNACK_GAME_RANKING: '/snack-game/ranking',
 
   BLOG: 'https://blog.snackga.me/',

--- a/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
+++ b/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
@@ -117,6 +117,7 @@ const SnackGameBizBase = ({ replaceErrorHandler }: Props) => {
 
   const handleGameEnd = async () => {
     const data = await gameEnd(session!.sessionId);
+    window.parent?.postMessage({ type: 'snackgameresult', payload: data }, '*');
 
     openModal({
       children: (

--- a/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
+++ b/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
+
+import { pixiState } from '@utils/atoms/game.atom';
+import { userState } from '@utils/atoms/member.atom';
+
+import { useGuest } from '@hooks/queries/auth.query';
+import useModal from '@hooks/useModal';
+
+import { SnackGameDefaultResponse } from '../SnackGame/game/game.type';
+import initializeApplication from '../SnackGame/game/hook/initializeApplication';
+import GameResult from './components/GameResult';
+import { PausePopup } from '../SnackGame/game/popup/PausePopup';
+import { RulePopup } from '../SnackGame/game/popup/RulePopup';
+import { SettingsPopup } from '../SnackGame/game/popup/SettingPopup';
+import { GameScreen } from '../SnackGame/game/screen/GameScreen';
+import { LobbyScreen } from '../SnackGame/game/screen/LobbyScreen';
+import { SnackgameApplication } from '../SnackGame/game/screen/SnackgameApplication';
+import {
+  gameEnd,
+  gamePause,
+  gameResume,
+  gameScore,
+  gameStart,
+} from './util/api';
+
+type Props = {
+  replaceErrorHandler: (handler: () => void) => void;
+};
+
+const SnackGameBizBase = ({ replaceErrorHandler }: Props) => {
+  const canvasBaseRef = useRef<HTMLDivElement>(null);
+  const { openModal } = useModal();
+
+  const pixiValue = useRecoilValue(pixiState);
+  const userInfo = useRecoilValue(userState);
+  const guestMutation = useGuest();
+  const queryClient = useQueryClient();
+
+  // TODO: 훅 안으로 끌고 들어가기
+  const initializeAppScreens = async (application: SnackgameApplication) => {
+    application.appScreenPool.insert(
+      [SettingsPopup, () => new SettingsPopup(application, handleGameResume)],
+      [RulePopup, () => new RulePopup(application)],
+      [
+        PausePopup,
+        () => new PausePopup(application, handleGameResume, handleGameEnd),
+      ],
+      [
+        LobbyScreen,
+        () =>
+          new LobbyScreen(application, handleSetMode, handleNonLoggedInUser),
+      ],
+      [
+        GameScreen,
+        () =>
+          new GameScreen(
+            application,
+            handleGetMode,
+            handleStreak,
+            handleGameStart,
+            handleGamePause,
+            handleGameEnd,
+          ),
+      ],
+    );
+    return application.appScreenPool;
+  };
+  const application = initializeApplication({
+    canvasBaseRef,
+    initializeAppScreens,
+  });
+
+  const handleApplicationError = () => {
+    application.show(LobbyScreen);
+  };
+
+  // 게임 진행 관련 functions
+  let session: SnackGameDefaultResponse | undefined;
+  let sessionMode: string | undefined;
+
+  const handleNonLoggedInUser = async () => {
+    if (!userInfo.id) await guestMutation.mutateAsync();
+  };
+
+  // TODO: 모드를 타입으로 정의해도 괜찮을 것 같습니다
+  const handleGameStart = async () => {
+    const data = await gameStart();
+    session = data;
+  };
+
+  // TODO: 현재 PixiJS 컨테이너와 게임의 모든 것이 결합되어있는데,
+  // 이것을 게임 상태(모드, 점수, 스트릭) 및 게임 규칙을 관리하는 순수한 스낵게임 클래스로 분리하면 좋겠네요.
+  // 지금 아래에 있는 getMode, handleStreak 같은 단순 상태를 가져오는 메서드들을 축약하고 싶어요!
+  const handleGetMode = () => sessionMode!;
+  const handleSetMode = (mode: string) => {
+    sessionMode = mode;
+  };
+
+  // TODO: 지금은 인자로 숫자를 사용하지만, '스트릭' VO를 만들어 사용하면 더 좋겠네요.
+  const handleStreak = async (streakLength: number) => {
+    session!.score += streakLength;
+    await gameScore(session!.score, session!.sessionId);
+  };
+
+  const handleGamePause = async () => {
+    if (!session || session.state === 'PAUSED') return;
+    session = await gamePause(session!.sessionId);
+  };
+
+  const handleGameResume = async () => {
+    if (!session) return;
+    session = await gameResume(session!.sessionId);
+  };
+
+  const handleGameEnd = async () => {
+    const data = await gameEnd(session!.sessionId);
+
+    openModal({
+      children: (
+        <GameResult
+          score={data.score}
+          percentile={data.percentile}
+          reStart={() => application.show(GameScreen)}
+        />
+      ),
+      handleOutsideClick: navigateToLobby,
+    });
+  };
+
+  const navigateToLobby = async () => {
+    session = undefined;
+    application.show(LobbyScreen);
+  };
+
+  useEffect(() => {
+    replaceErrorHandler(handleApplicationError);
+  }, []);
+
+  useEffect(() => {
+    if (pixiValue.assetsInit && !userInfo.id) navigateToLobby();
+  }, []);
+  return (
+    <div ref={canvasBaseRef} className={'mx-auto h-full w-full max-w-xl'}></div>
+  );
+};
+
+export default SnackGameBizBase;

--- a/src/pages/games/SnackgameBiz/SnackGameBizPage.tsx
+++ b/src/pages/games/SnackgameBiz/SnackGameBizPage.tsx
@@ -1,0 +1,29 @@
+import { Helmet } from 'react-helmet-async';
+
+import ErrorBoundary from '@components/base/ErrorBoundary';
+import RetryError from '@components/Error/RetryError';
+
+import SnackGameBizBase from './SnackGameBizBase';
+
+const SnackGameBizPage = () => {
+  let errorHandler = () => {
+    console.log('SnackgameBase 초기화 전 오류가 발생했습니다');
+  };
+  const replaceErrorHandler = (handler: () => void) => (errorHandler = handler);
+
+  return (
+    <>
+      <Helmet>
+        <title>Snack Game || Snack Game</title>
+      </Helmet>
+
+      <div className={'h-screen bg-game'}>
+        <ErrorBoundary fallback={RetryError} onReset={errorHandler}>
+          <SnackGameBizBase replaceErrorHandler={replaceErrorHandler} />
+        </ErrorBoundary>
+      </div>
+    </>
+  );
+};
+
+export default SnackGameBizPage;

--- a/src/pages/games/SnackgameBiz/components/GameResult.tsx
+++ b/src/pages/games/SnackgameBiz/components/GameResult.tsx
@@ -1,0 +1,33 @@
+import Button from '@components/Button/Button';
+import useModal from '@hooks/useModal';
+
+interface GameResultProps {
+  score: number;
+  percentile: number;
+  reStart: () => void;
+}
+
+const GameResult = ({ score, percentile, reStart }: GameResultProps) => {
+  const { closeModal } = useModal();
+
+  const handleReStartButton = () => {
+    reStart();
+    closeModal();
+  };
+
+  return (
+    <div className={'flex w-full flex-grow flex-col justify-evenly gap-4'}>
+      <div className={'mx-auto flex flex-col items-center gap-4 font-semibold'}>
+        <p className="text-6xl text-primary">{score}점</p>
+
+        <p>전체 사용자 중 상위 {percentile}%의 점수에요!</p>
+
+        <Button onClick={handleReStartButton} size={'lg'}>
+          재시작!
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default GameResult;

--- a/src/pages/games/SnackgameBiz/util/api.ts
+++ b/src/pages/games/SnackgameBiz/util/api.ts
@@ -1,0 +1,47 @@
+import api from '@api/index';
+
+import {
+  SnackGameDefaultResponse,
+  SnackGameEnd,
+  SnackGamePause,
+  SnackGameStart,
+} from '../../SnackGame/game/game.type';
+
+const GAME_ID = 4;
+
+export const gameStart = async (): Promise<SnackGameStart> => {
+  const { data } = await api.post(`/games/${GAME_ID}`);
+
+  return data;
+};
+
+export const gameScore = async (
+  score: number,
+  sessionId: number,
+): Promise<SnackGameDefaultResponse> => {
+  const { data } = await api.put(`/games/${GAME_ID}/${sessionId}`, {
+    score,
+  });
+
+  return data;
+};
+
+export const gamePause = async (sessionId: number): Promise<SnackGamePause> => {
+  const { data } = await api.post(`games/${GAME_ID}/${sessionId}/pause`);
+
+  return data;
+};
+
+export const gameResume = async (
+  sessionId: number,
+): Promise<SnackGameDefaultResponse> => {
+  const { data } = await api.post(`games/${GAME_ID}/${sessionId}/resume`);
+
+  return data;
+};
+
+export const gameEnd = async (sessionId: number): Promise<SnackGameEnd> => {
+  const { data } = await api.post(`games/${GAME_ID}/${sessionId}/end`);
+
+  return data;
+};


### PR DESCRIPTION
## 💻 개요
- resolves: #304 

## 📋 변경 및 추가 사항
<img width="400" alt="image" src="https://github.com/user-attachments/assets/fd1a501b-10fb-48a9-b948-652e363a5cbe">

기존 스낵게임 페이지와 별도로 Snackgame Biz 페이지를 추가합니다.
- 게임은 우선 게스트로 진행됩니다.
- 게임 결과는 `postMessage`를 통해 제공됩니다. (추후 JWT 적용 예정)
- 랭킹 및 프로필 서비스는 (아직) 제공되지 않습니다.

자세한 사용 방법은 별도의 문서를 만들어 블로그를 통해 배포 예정입니다.

## 💬 To. 리뷰어
오늘 스낵게임 관련 미팅이 있어서 선 머지 후 리뷰를 반영하겠습니다!
양해 부탁드립니다 🙇🏻🙇🏻🙇🏻
