### PR TITLE
fix: `handleNonLoggedInUser`에서 최신 `userInfo`를 반영하지 못하는 문제 수정

### DIFF
--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -7,6 +7,7 @@ import { pixiState } from '@utils/atoms/game.atom';
 import { userState } from '@utils/atoms/member.atom';
 
 import { QUERY_KEY } from '@constants/api.constant';
+import { ATOM_KEY } from '@constants/atom.constant';
 import { useGuest } from '@hooks/queries/auth.query';
 import useModal from '@hooks/useModal';
 
@@ -83,7 +84,10 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
   let sessionMode: string | undefined;
 
   const handleNonLoggedInUser = async () => {
-    if (!userInfo.id) await guestMutation.mutateAsync();
+    const isLoggedIn = JSON.parse(
+      window.localStorage.getItem(ATOM_KEY.USER_PERSIST) || '{}',
+    ).userState;
+    if (!isLoggedIn) await guestMutation.mutateAsync();
   };
 
   // TODO: 모드를 타입으로 정의해도 괜찮을 것 같습니다


### PR DESCRIPTION
## 💻 개요

- 이슈 대응

- #290 

## 📋 변경 및 추가 사항

- `handleNonLoggedInUser` 내에서 로컬 스토리지 값을 바로 읽도록 했습니다

![auto_guest](https://github.com/user-attachments/assets/e442f71a-2a1b-4310-8ef9-8d3d6855b004)

(움짤이 좀 기네요 😅 아래 내용을 녹화했습니다)

(1) 로그아웃 상태에서 자동 게스트 로그인 성공
➡️ (2) 로그인 이후 해당 계정으로 게임 시작 성공
➡️ (3) 로그아웃 후 자동 게스트 로그인 성공

## 💬 To. 리뷰어

이슈 코멘트로 문제 상황과 수정 방향에 대한 내용 나누어서 바로 머지하겠습니다!