### PR TITLE
feat: 게임판 검증 API 적용

### DIFF
--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -125,7 +125,6 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
 
   const handleGamePause = async () => {
     if (!session || session.state === 'PAUSED') return;
-
     if (cumulativeStreaks.length > 0) {
       await handleStreaksMove();
     }

--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -92,8 +92,8 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
 
   // TODO: 모드를 타입으로 정의해도 괜찮을 것 같습니다
   const handleGameStart = async () => {
-    const data = await gameStart();
-    session = data;
+    session = await gameStart();
+    return session;
   };
 
   // TODO: 현재 PixiJS 컨테이너와 게임의 모든 것이 결합되어있는데,

--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -22,7 +22,7 @@ import { LobbyScreen } from './screen/LobbyScreen';
 import { SnackgameApplication } from './screen/SnackgameApplication';
 import { Streak } from './snackGame/SnackGameUtil';
 import {
-  checkMoves,
+  verifyStreaks,
   gameEnd,
   gamePause,
   gameResume,
@@ -118,7 +118,7 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
   };
 
   const handleStreaksMove = async (): Promise<SnackGameVerify | void> => {
-    const result = await checkMoves(session!.sessionId, cumulativeStreaks);
+    const result = await verifyStreaks(session!.sessionId, cumulativeStreaks);
     cumulativeStreaks = [];
     return result;
   };

--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -111,13 +111,12 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
     cumulativeStreaks = [...cumulativeStreaks, streak];
 
     if (isGolden) {
-      const result = await handleStreaksMove();
-      if (result) session = result;
-      return result;
+      session = await handleStreaksMove();
     }
+    return session!;
   };
 
-  const handleStreaksMove = async (): Promise<SnackGameVerify | void> => {
+  const handleStreaksMove = async (): Promise<SnackGameVerify> => {
     const result = await verifyStreaks(session!.sessionId, cumulativeStreaks);
     cumulativeStreaks = [];
     return result;

--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -20,7 +20,7 @@ import { SettingsPopup } from './popup/SettingPopup';
 import { GameScreen } from './screen/GameScreen';
 import { LobbyScreen } from './screen/LobbyScreen';
 import { SnackgameApplication } from './screen/SnackgameApplication';
-import { StreakPosition } from './snackGame/SnackGameUtil';
+import { Streak } from './snackGame/SnackGameUtil';
 import {
   checkMoves,
   gameEnd,
@@ -83,7 +83,7 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
   // 게임 진행 관련 functions
   let session: SnackGameDefaultResponse | undefined;
   let sessionMode: string | undefined;
-  let cumulativeStreaks: StreakPosition[][] = [];
+  let cumulativeStreaks: Streak[] = [];
 
   const handleNonLoggedInUser = async () => {
     const isLoggedIn = JSON.parse(
@@ -107,7 +107,7 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
   };
 
   // TODO: 지금은 인자로 숫자를 사용하지만, '스트릭' VO를 만들어 사용하면 더 좋겠네요.
-  const handleStreak = async (streaks: StreakPosition[], isGolden: boolean) => {
+  const handleStreak = async (streaks: Streak, isGolden: boolean) => {
     cumulativeStreaks = [...cumulativeStreaks, streaks];
 
     if (isGolden) {

--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -107,17 +107,17 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
   };
 
   // TODO: 지금은 인자로 숫자를 사용하지만, '스트릭' VO를 만들어 사용하면 더 좋겠네요.
-  const handleStreak = async (streaks: Streak, isGolden: boolean) => {
-    cumulativeStreaks = [...cumulativeStreaks, streaks];
+  const handleStreak = async (streak: Streak, isGolden: boolean) => {
+    cumulativeStreaks = [...cumulativeStreaks, streak];
 
     if (isGolden) {
-      const result = await handleStreakMove();
+      const result = await handleStreaksMove();
       if (result) session = result;
       return result;
     }
   };
 
-  const handleStreakMove = async (): Promise<SnackGameVerify | void> => {
+  const handleStreaksMove = async (): Promise<SnackGameVerify | void> => {
     const result = await checkMoves(session!.sessionId, cumulativeStreaks);
     cumulativeStreaks = [];
     return result;
@@ -127,7 +127,7 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
     if (!session || session.state === 'PAUSED') return;
 
     if (cumulativeStreaks.length > 0) {
-      await handleStreakMove();
+      await handleStreaksMove();
     }
 
     session = await gamePause(session!.sessionId);
@@ -140,7 +140,7 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
 
   const handleGameEnd = async () => {
     if (cumulativeStreaks.length > 0) {
-      await handleStreakMove();
+      await handleStreaksMove();
     }
 
     const data = await gameEnd(session!.sessionId);

--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -20,11 +20,12 @@ import { SettingsPopup } from './popup/SettingPopup';
 import { GameScreen } from './screen/GameScreen';
 import { LobbyScreen } from './screen/LobbyScreen';
 import { SnackgameApplication } from './screen/SnackgameApplication';
+import { StreakPosition } from './snackGame/SnackGameUtil';
 import {
+  checkMoves,
   gameEnd,
   gamePause,
   gameResume,
-  gameScore,
   gameStart,
 } from './util/api';
 
@@ -105,9 +106,9 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
   };
 
   // TODO: 지금은 인자로 숫자를 사용하지만, '스트릭' VO를 만들어 사용하면 더 좋겠네요.
-  const handleStreak = async (streakLength: number) => {
-    session!.score += streakLength;
-    await gameScore(session!.score, session!.sessionId);
+  const handleStreak = async (streaks: StreakPosition[][]) => {
+    session = await checkMoves(session!.sessionId, streaks);
+    return session;
   };
 
   const handleGamePause = async () => {

--- a/src/pages/games/SnackGame/game/game.type.ts
+++ b/src/pages/games/SnackGame/game/game.type.ts
@@ -22,6 +22,8 @@ export interface SnackGameDefaultResponse {
 
 export type SnackGameStart = SnackGameDefaultResponse;
 
+export type SnackGameVerify = SnackGameDefaultResponse;
+
 export type SnackGamePause = SnackGameDefaultResponse;
 
 export type SnackGameEnd = SnackGameDefaultResponse & {

--- a/src/pages/games/SnackGame/game/game.type.ts
+++ b/src/pages/games/SnackGame/game/game.type.ts
@@ -2,6 +2,11 @@ export type SnackGameMod = 'default' | 'inf';
 
 export type SnackGameAPIStats = 'IN_PROGRESS' | 'PAUSED' | 'EXPIRED';
 
+export type SnackResponse = {
+  number: number;
+  golden: boolean;
+};
+
 export interface SnackGameDefaultResponse {
   metadata: {
     gameId: number;
@@ -12,7 +17,7 @@ export interface SnackGameDefaultResponse {
   state: SnackGameAPIStats;
   score: number;
   createdAt: string;
-  board: string;
+  board: SnackResponse[][];
 }
 
 export type SnackGameStart = SnackGameDefaultResponse;

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -3,6 +3,7 @@ import { Container, Rectangle, Ticker } from 'pixi.js';
 
 import { AppScreen, AppScreenConstructor } from './appScreen';
 import { SnackgameApplication } from './SnackgameApplication';
+import { SnackGameStart } from '../game.type';
 import { PausePopup } from '../popup/PausePopup';
 import { SettingsPopup } from '../popup/SettingPopup';
 import { SnackGame, SnackGameOnPopData } from '../snackGame/SnackGame';
@@ -42,7 +43,7 @@ export class GameScreen extends Container implements AppScreen {
     private app: SnackgameApplication,
     private getCurrentMode: () => string,
     private handleStreak: (streakLength: number) => Promise<void>,
-    private handleGameStart: () => Promise<void>,
+    private handleGameStart: () => Promise<SnackGameStart>,
     private handleGamePause: () => Promise<void>,
     private handleGameEnd: () => Promise<void>,
   ) {
@@ -95,17 +96,18 @@ export class GameScreen extends Container implements AppScreen {
   }
 
   public async onPrepare({ width, height }: Rectangle) {
+    const { board } = await this.handleGameStart();
     const mode = this.getCurrentMode() as SnackGameMode;
 
     const snackGameConfig = snackGameGetConfig({
-      rows: 8,
-      columns: 6,
+      rows: board.length,
+      columns: board[0].length,
       duration: 120,
       mode,
     });
 
     this.finished = false;
-    this.snackGame.setup(snackGameConfig);
+    this.snackGame.setup(snackGameConfig, board);
     this.score.hide(false);
     this.pauseButton.hide(false);
     this.timer.hide(false);
@@ -189,7 +191,6 @@ export class GameScreen extends Container implements AppScreen {
     this.onSnackGameBoardReset();
     await waitFor(0.6);
     await this.beforeGameStart.hide();
-    await this.handleGameStart();
     this.snackGame.startPlaying();
   }
 

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -120,12 +120,13 @@ export class GameScreen extends Container implements AppScreen {
     const snackGameConfig = snackGameGetConfig({
       rows: board.length,
       columns: board[0].length,
-      duration: 120,
+      duration: 121,
       mode,
     });
+    this.snackGame.setup(snackGameConfig, board);
+    this.snackGame.startPlaying(); // TODO: onPrepare로 이동시키면서 시간을 1초 늘렸는데, 다른 방법이 없을지?
 
     this.finished = false;
-    this.snackGame.setup(snackGameConfig, board);
     this.score.hide(false);
     this.pauseButton.hide(false);
     this.timer.hide(false);
@@ -209,7 +210,6 @@ export class GameScreen extends Container implements AppScreen {
     this.onSnackGameBoardReset();
     await waitFor(0.6);
     await this.beforeGameStart.hide();
-    this.snackGame.startPlaying();
   }
 
   public async onHide({ width, height }: Rectangle) {

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -120,7 +120,7 @@ export class GameScreen extends Container implements AppScreen {
     const snackGameConfig = snackGameGetConfig({
       rows: board.length,
       columns: board[0].length,
-      duration: 20,
+      duration: 120,
       mode,
     });
 

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -3,11 +3,16 @@ import { Container, Rectangle, Ticker } from 'pixi.js';
 
 import { AppScreen, AppScreenConstructor } from './appScreen';
 import { SnackgameApplication } from './SnackgameApplication';
-import { SnackGameStart } from '../game.type';
+import { SnackGameStart, SnackGameVerify } from '../game.type';
 import { PausePopup } from '../popup/PausePopup';
 import { SettingsPopup } from '../popup/SettingPopup';
+import { Snack } from '../snackGame/Snack';
 import { SnackGame, SnackGameOnPopData } from '../snackGame/SnackGame';
-import { SnackGameMode, snackGameGetConfig } from '../snackGame/SnackGameUtil';
+import {
+  SnackGameMode,
+  StreakPosition,
+  snackGameGetConfig,
+} from '../snackGame/SnackGameUtil';
 import { BeforeGameStart } from '../ui/BeforeGameStart';
 import { GameEffects } from '../ui/GameEffect';
 import { IconButton } from '../ui/IconButton';
@@ -42,7 +47,9 @@ export class GameScreen extends Container implements AppScreen {
   constructor(
     private app: SnackgameApplication,
     private getCurrentMode: () => string,
-    private handleStreak: (streakLength: number) => Promise<void>,
+    private handleStreak: (
+      streaks: StreakPosition[][],
+    ) => Promise<SnackGameVerify>,
     private handleGameStart: () => Promise<SnackGameStart>,
     private handleGamePause: () => Promise<void>,
     private handleGameEnd: () => Promise<void>,
@@ -77,8 +84,14 @@ export class GameScreen extends Container implements AppScreen {
 
     this.snackGame = new SnackGame();
     this.snackGame.onPop = this.onPop.bind(this);
-    this.snackGame.onStreak = (data: any[]) => {
-      this.handleStreak(data.length);
+    this.snackGame.onStreak = (data: Snack[]) => {
+      const streaks = data.reduce((acc: StreakPosition[], snack) => {
+        const { row: x, column: y } = snack.getGridPosition();
+        acc.push({ x, y });
+        return acc;
+      }, []);
+
+      return this.handleStreak([streaks]);
     };
     this.snackGame.onSnackGameBoardReset =
       this.onSnackGameBoardReset.bind(this);

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -86,7 +86,7 @@ export class GameScreen extends Container implements AppScreen {
     this.snackGame.onPop = this.onPop.bind(this);
     this.snackGame.onStreak = (data: Snack[]) => {
       const streaks = data.reduce((acc: StreakPosition[], snack) => {
-        const { row: x, column: y } = snack.getGridPosition();
+        const { row: y, column: x } = snack.getGridPosition();
         acc.push({ x, y });
         return acc;
       }, []);

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -10,7 +10,7 @@ import { Snack } from '../snackGame/Snack';
 import { SnackGame, SnackGameOnPopData } from '../snackGame/SnackGame';
 import {
   SnackGameMode,
-  StreakPosition,
+  Streak,
   snackGameGetConfig,
 } from '../snackGame/SnackGameUtil';
 import { BeforeGameStart } from '../ui/BeforeGameStart';
@@ -48,7 +48,7 @@ export class GameScreen extends Container implements AppScreen {
     private app: SnackgameApplication,
     private getCurrentMode: () => string,
     private handleStreak: (
-      streaks: StreakPosition[],
+      streaks: Streak,
       isGolden: boolean,
     ) => Promise<SnackGameVerify | void>,
     private handleGameStart: () => Promise<SnackGameStart>,
@@ -88,7 +88,7 @@ export class GameScreen extends Container implements AppScreen {
     this.snackGame.onStreak = (data: Snack[]) => {
       let isGolden = false;
 
-      const streaks = data.reduce((acc: StreakPosition[], snack) => {
+      const streaks = data.reduce((acc: Streak, snack) => {
         if (snack.type === 2) isGolden = true;
 
         const { row: y, column: x } = snack.getGridPosition();

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -48,8 +48,9 @@ export class GameScreen extends Container implements AppScreen {
     private app: SnackgameApplication,
     private getCurrentMode: () => string,
     private handleStreak: (
-      streaks: StreakPosition[][],
-    ) => Promise<SnackGameVerify>,
+      streaks: StreakPosition[],
+      isGolden: boolean,
+    ) => Promise<SnackGameVerify | void>,
     private handleGameStart: () => Promise<SnackGameStart>,
     private handleGamePause: () => Promise<void>,
     private handleGameEnd: () => Promise<void>,
@@ -85,13 +86,17 @@ export class GameScreen extends Container implements AppScreen {
     this.snackGame = new SnackGame();
     this.snackGame.onPop = this.onPop.bind(this);
     this.snackGame.onStreak = (data: Snack[]) => {
+      let isGolden = false;
+
       const streaks = data.reduce((acc: StreakPosition[], snack) => {
+        if (snack.type === 2) isGolden = true;
+
         const { row: y, column: x } = snack.getGridPosition();
         acc.push({ x, y });
         return acc;
       }, []);
 
-      return this.handleStreak([streaks]);
+      return this.handleStreak(streaks, isGolden);
     };
     this.snackGame.onSnackGameBoardReset =
       this.onSnackGameBoardReset.bind(this);
@@ -115,7 +120,7 @@ export class GameScreen extends Container implements AppScreen {
     const snackGameConfig = snackGameGetConfig({
       rows: board.length,
       columns: board[0].length,
-      duration: 120,
+      duration: 20,
       mode,
     });
 

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -48,7 +48,7 @@ export class GameScreen extends Container implements AppScreen {
     private app: SnackgameApplication,
     private getCurrentMode: () => string,
     private handleStreak: (
-      streaks: Streak,
+      streak: Streak,
       isGolden: boolean,
     ) => Promise<SnackGameVerify | void>,
     private handleGameStart: () => Promise<SnackGameStart>,
@@ -88,7 +88,7 @@ export class GameScreen extends Container implements AppScreen {
     this.snackGame.onStreak = (data: Snack[]) => {
       let isGolden = false;
 
-      const streaks = data.reduce((acc: Streak, snack) => {
+      const streak = data.reduce((acc: Streak, snack) => {
         if (snack.type === 2) isGolden = true;
 
         const { row: y, column: x } = snack.getGridPosition();
@@ -96,7 +96,7 @@ export class GameScreen extends Container implements AppScreen {
         return acc;
       }, []);
 
-      return this.handleStreak(streaks, isGolden);
+      return this.handleStreak(streak, isGolden);
     };
     this.snackGame.onSnackGameBoardReset =
       this.onSnackGameBoardReset.bind(this);

--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -50,7 +50,7 @@ export class GameScreen extends Container implements AppScreen {
     private handleStreak: (
       streak: Streak,
       isGolden: boolean,
-    ) => Promise<SnackGameVerify | void>,
+    ) => Promise<SnackGameVerify>,
     private handleGameStart: () => Promise<SnackGameStart>,
     private handleGamePause: () => Promise<void>,
     private handleGameEnd: () => Promise<void>,

--- a/src/pages/games/SnackGame/game/snackGame/SnackGame.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGame.ts
@@ -11,6 +11,7 @@ import {
   snackGameGetConfig,
   SnackType,
 } from './SnackGameUtil';
+import { SnackResponse } from '../game.type';
 
 /** onMatch 이벤트 데이터에 대한 인터페이스 */
 export interface SnackGameOnMatchData {
@@ -75,10 +76,10 @@ export class SnackGame extends Container {
    * 조각, 행, 열, 지속 시간 등을 포함하여 새로운 SnackGame 게임을 설정
    * @param config 게임이 기반으로 할 설정 객체
    */
-  public setup(config: SnackGameConfig) {
+  public setup(config: SnackGameConfig, board: SnackResponse[][]) {
     this.config = config;
     this.reset();
-    this.board.setup(config);
+    this.board.setup(config, board);
     this.timer.setup(config.duration * 1000);
   }
 

--- a/src/pages/games/SnackGame/game/snackGame/SnackGame.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGame.ts
@@ -55,7 +55,7 @@ export class SnackGame extends Container {
   public onMatch?: (data: SnackGameOnMatchData) => void;
   /** 보드에서 조각이 팝될 때 발생 */
   public onPop?: (data: SnackGameOnPopData) => void;
-  public onStreak?: (data: Snack[]) => Promise<SnackGameVerify>;
+  public onStreak?: (data: Snack[]) => Promise<SnackGameVerify | void>;
   /** 게임 시간이 만료되면 발생 */
   public onTimesUp?: () => void;
   /** SnackGameBoard 리셋 시 발생*/

--- a/src/pages/games/SnackGame/game/snackGame/SnackGame.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGame.ts
@@ -11,7 +11,7 @@ import {
   snackGameGetConfig,
   SnackType,
 } from './SnackGameUtil';
-import { SnackResponse } from '../game.type';
+import { SnackGameVerify, SnackResponse } from '../game.type';
 
 /** onMatch 이벤트 데이터에 대한 인터페이스 */
 export interface SnackGameOnMatchData {
@@ -55,7 +55,7 @@ export class SnackGame extends Container {
   public onMatch?: (data: SnackGameOnMatchData) => void;
   /** 보드에서 조각이 팝될 때 발생 */
   public onPop?: (data: SnackGameOnPopData) => void;
-  public onStreak?: (data: Snack[]) => void;
+  public onStreak?: (data: Snack[]) => Promise<SnackGameVerify>;
   /** 게임 시간이 만료되면 발생 */
   public onTimesUp?: () => void;
   /** SnackGameBoard 리셋 시 발생*/

--- a/src/pages/games/SnackGame/game/snackGame/SnackGame.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGame.ts
@@ -55,7 +55,7 @@ export class SnackGame extends Container {
   public onMatch?: (data: SnackGameOnMatchData) => void;
   /** 보드에서 조각이 팝될 때 발생 */
   public onPop?: (data: SnackGameOnPopData) => void;
-  public onStreak?: (data: Snack[]) => Promise<SnackGameVerify | void>;
+  public onStreak?: (data: Snack[]) => Promise<SnackGameVerify>;
   /** 게임 시간이 만료되면 발생 */
   public onTimesUp?: () => void;
   /** SnackGameBoard 리셋 시 발생*/

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameAction.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameAction.ts
@@ -16,7 +16,7 @@ export class SnackGameActions {
   /** Snack 객체에게 onPointerDown이벤트 시 실행할 콜백을 넘깁니다.
    * @param position 타겟 스낵 그리드 위치
    */
-  public actionTap(position: SnackGamePosition) {
+  public async actionTap(position: SnackGamePosition) {
     if (!this.snackGame.isPlaying()) return;
     sfx.play('common/sfx-select.mp3');
 
@@ -30,13 +30,13 @@ export class SnackGameActions {
 
     if (sum === 10) {
       sfx.play('common/sfx-match.mp3', { speed: 1.2, volume: 0.5 });
-      this.snackGame.board.popAllSelectedSnacks();
+      const session = await this.snackGame.board.popAllSelectedSnacks();
 
       // TODO: 지금은 특수 기물이 황금사과 하나지만 나중에 확장 될 경우 opens-games처럼 특수 기물을 따로 관리해주어야함.
       this.snackGame.board.selectedSnacks.forEach((snack) => {
         if (snack.type === 2) {
           this.snackGame.board.reset();
-          this.snackGame.board.setup(this.snackGame.config);
+          this.snackGame.board.setup(this.snackGame.config, session!.board);
           this.snackGame.onSnackGameBoardReset?.();
         }
       });

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameBoard.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameBoard.ts
@@ -3,16 +3,16 @@ import { Container, Graphics } from 'pixi.js';
 import { Snack } from './Snack';
 import { SnackGame } from './SnackGame';
 import {
-  snackGameForEach,
   SnackGamePosition,
   SnackGameConfig,
-  snackGameCreateGrid,
   snackGameGetSnack,
   SnackGameGrid,
   SnackType,
   snackGameGetSnackType,
   snackGameSetPieceType,
+  snackGameCreateGrid,
 } from './SnackGameUtil';
+import { SnackResponse } from '../game.type';
 import { pool } from '../util/pool';
 
 export class SnackGameBoard {
@@ -56,7 +56,7 @@ export class SnackGameBoard {
    * 초기 격자 상태를 설정하고 뷰를 스낵으로 채움
    * @param config 스낵게임 설정 매개 변수
    */
-  public setup(config: SnackGameConfig) {
+  public setup(config: SnackGameConfig, board: SnackResponse[][]) {
     this.rows = config.rows;
     this.columns = config.columns;
     this.tileSize = 50;
@@ -80,15 +80,14 @@ export class SnackGameBoard {
     }
 
     // 초기 격자 상태 생성
-    this.grid = snackGameCreateGrid(this.rows, this.columns, this.commonTypes);
+    this.grid = snackGameCreateGrid(this.rows, this.columns, board);
 
-    // 시각적 보드를 스낵 스프라이트로 채우기
-    snackGameForEach(
-      this.grid,
-      (gridPosition: SnackGamePosition, type: SnackType) => {
-        this.createSnack(gridPosition, type);
-      },
-    );
+    // 서버에서 준 board 정보로 보드에 스낵 스프라이트 채우기
+    board.forEach((rowSnack, row) => {
+      rowSnack.forEach((snack, column) => {
+        this.createSnack({ row, column }, snack);
+      });
+    });
   }
 
   /**
@@ -108,16 +107,17 @@ export class SnackGameBoard {
    * @param position 새 스낵이 붙을 그리드 위치
    * @param snackType 새 스낵의 유형
    */
-  public createSnack(position: SnackGamePosition, snackType: SnackType) {
-    const name = this.typesMap[snackType];
+  public createSnack(position: SnackGamePosition, snackInfo: SnackResponse) {
+    const type = snackInfo.golden ? 2 : 1;
+    const name = this.typesMap[type];
     const snack = pool.get(Snack);
     const viewPosition = this.getViewPositionByGridPosition(position);
     snack.onTap = (position) => this.snackGame.actions.actionTap(position);
     snack.setup({
       name,
-      type: snackType,
+      type,
       interactive: true,
-      snackNum: Math.floor(Math.random() * 9) + 1,
+      snackNum: snackInfo.number,
     });
     snack.row = position.row;
     snack.column = position.column;

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameBoard.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameBoard.ts
@@ -230,10 +230,11 @@ export class SnackGameBoard {
 
   /** 선택된 스낵들을 모두 pop */
   public popAllSelectedSnacks() {
-    this.snackGame.onStreak?.(this.selectedSnacks);
+    const session = this.snackGame.onStreak?.(this.selectedSnacks);
     for (const snack of this.selectedSnacks) {
       this.popSnack(snack.getGridPosition());
     }
+    return session;
   }
 
   /** 모든 스낵이 선택 가능하게  */

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameUtil.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameUtil.ts
@@ -1,3 +1,5 @@
+import { SnackResponse } from '../game.type';
+
 /** 각 그리드 내부 스낵 타입 */
 export type SnackType = number;
 
@@ -58,41 +60,18 @@ export function snackGameGetSnack(mode: SnackGameMode): string[] {
  * @param types 채워야 하는 스낵 타입들
  * @returns 스낵 타입들로 채워진 2차원 배열
  */
-export function snackGameCreateGrid(rows = 6, columns = 6, types: SnackType[]) {
+export function snackGameCreateGrid(
+  rows = 6,
+  columns = 6,
+  board: SnackResponse[][],
+) {
   const grid: SnackGameGrid = [];
-  const gimmickSnackIndex = [];
-
-  /**
-   * SnackType이 1보다 길다면 기믹을 가진 스낵이 존재함을 의미합니다.
-   * 해당 기믹 스낵이 생성될 위치를 미리 계산합니다.
-   * type은 1부터 시작하며 1은 기본 스낵 2부터는 기믹 스낵 입니다.
-   */
-  if (types.length > 1) {
-    for (let i = 2; i <= types.length; i++) {
-      // TODO 기믹을 가진 스낵이 중복된 위치를 가지지 못 하도록 해야합니다.
-      const randomRow = Math.floor(Math.random() * rows);
-      const randomColumn = Math.floor(Math.random() * columns);
-
-      gimmickSnackIndex.push({ row: randomRow, column: randomColumn, type: i });
-    }
-  }
 
   for (let r = 0; r < rows; r++) {
     const types = [];
 
     for (let c = 0; c < columns; c++) {
-      let currentType = 1;
-      const position: SnackGamePosition = { row: r, column: c };
-
-      for (const gimmick of gimmickSnackIndex) {
-        if (
-          position.row === gimmick.row &&
-          position.column === gimmick.column
-        ) {
-          currentType = gimmick.type;
-        }
-      }
-
+      const currentType = board[r][c].golden ? 2 : 1;
       types.push(currentType);
     }
 

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameUtil.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameUtil.ts
@@ -8,7 +8,9 @@ export type SnackGameGrid = SnackType[][];
 
 /** 그리드 내부 좌표 타입 */
 export type SnackGamePosition = { row: number; column: number };
-export type StreakPosition = { x: number; y: number }; // TODO: SnackGamePosition과 합치기
+
+/** 스트릭 (내부 좌표의 모음) 타입 */
+export type Streak = { x: number; y: number }[];
 
 /** 게임 모드 */
 export const snackGameModes = ['default', 'inf'] as const;

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameUtil.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameUtil.ts
@@ -1,7 +1,7 @@
 import { SnackResponse } from '../game.type';
 
 /** 각 그리드 내부 스낵 타입 */
-export type SnackType = number;
+export type SnackType = number; // TODO: 타입 안정성과 가독성을 위해 새로운 타입으로 정의
 
 /** 스낵게임 board를 표현하는 2차원 배열 타입 */
 export type SnackGameGrid = SnackType[][];

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameUtil.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameUtil.ts
@@ -64,8 +64,8 @@ export function snackGameGetSnack(mode: SnackGameMode): string[] {
  * @returns 스낵 타입들로 채워진 2차원 배열
  */
 export function snackGameCreateGrid(
-  rows = 6,
-  columns = 6,
+  rows: number,
+  columns: number,
   board: SnackResponse[][],
 ) {
   const grid: SnackGameGrid = [];

--- a/src/pages/games/SnackGame/game/snackGame/SnackGameUtil.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGameUtil.ts
@@ -8,6 +8,7 @@ export type SnackGameGrid = SnackType[][];
 
 /** 그리드 내부 좌표 타입 */
 export type SnackGamePosition = { row: number; column: number };
+export type StreakPosition = { x: number; y: number }; // TODO: SnackGamePosition과 합치기
 
 /** 게임 모드 */
 export const snackGameModes = ['default', 'inf'] as const;

--- a/src/pages/games/SnackGame/game/util/api.ts
+++ b/src/pages/games/SnackGame/game/util/api.ts
@@ -24,17 +24,6 @@ export const checkMoves = async (
   return data;
 };
 
-export const gameScore = async (
-  score: number,
-  sessionId: number,
-): Promise<SnackGameDefaultResponse> => {
-  const { data } = await api.put(`/games/2/${sessionId}`, {
-    score,
-  });
-
-  return data;
-};
-
 export const gamePause = async (sessionId: number): Promise<SnackGamePause> => {
   const { data } = await api.post(`games/2/${sessionId}/pause`);
 

--- a/src/pages/games/SnackGame/game/util/api.ts
+++ b/src/pages/games/SnackGame/game/util/api.ts
@@ -7,7 +7,7 @@ import {
   SnackGameStart,
   SnackGameVerify,
 } from '../game.type';
-import { StreakPosition } from '../snackGame/SnackGameUtil';
+import { Streak } from '../snackGame/SnackGameUtil';
 
 export const gameStart = async (): Promise<SnackGameStart> => {
   const { data } = await api.post('/games/2');
@@ -17,7 +17,7 @@ export const gameStart = async (): Promise<SnackGameStart> => {
 
 export const checkMoves = async (
   sessionId: number,
-  streaks: StreakPosition[][],
+  streaks: Streak[],
 ): Promise<SnackGameVerify> => {
   const { data } = await api.post(`/games/2/${sessionId}/streaks`, { streaks });
 

--- a/src/pages/games/SnackGame/game/util/api.ts
+++ b/src/pages/games/SnackGame/game/util/api.ts
@@ -15,7 +15,7 @@ export const gameStart = async (): Promise<SnackGameStart> => {
   return data;
 };
 
-export const checkMoves = async (
+export const verifyStreaks = async (
   sessionId: number,
   streaks: Streak[],
 ): Promise<SnackGameVerify> => {

--- a/src/pages/games/SnackGame/game/util/api.ts
+++ b/src/pages/games/SnackGame/game/util/api.ts
@@ -5,10 +5,21 @@ import {
   SnackGameEnd,
   SnackGamePause,
   SnackGameStart,
+  SnackGameVerify,
 } from '../game.type';
+import { StreakPosition } from '../snackGame/SnackGameUtil';
 
 export const gameStart = async (): Promise<SnackGameStart> => {
   const { data } = await api.post('/games/2');
+
+  return data;
+};
+
+export const checkMoves = async (
+  sessionId: number,
+  streaks: StreakPosition[][],
+): Promise<SnackGameVerify> => {
+  const { data } = await api.post(`/games/2/${sessionId}/streaks`, { streaks });
 
   return data;
 };

--- a/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
+++ b/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
@@ -109,13 +109,12 @@ const SnackGameBizBase = ({ replaceErrorHandler }: Props) => {
     cumulativeStreaks = [...cumulativeStreaks, streak];
 
     if (isGolden) {
-      const result = await handleStreaksMove();
-      if (result) session = result;
-      return result;
+      session = await handleStreaksMove();
     }
+    return session!;
   };
 
-  const handleStreaksMove = async (): Promise<SnackGameVerify | void> => {
+  const handleStreaksMove = async (): Promise<SnackGameVerify> => {
     const result = await verifyStreaks(session!.sessionId, cumulativeStreaks);
     cumulativeStreaks = [];
     return result;

--- a/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
+++ b/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
@@ -11,7 +11,7 @@ import useModal from '@hooks/useModal';
 
 import GameResult from './components/GameResult';
 import {
-  checkMoves,
+  verifyStreaks,
   gameEnd,
   gamePause,
   gameResume,
@@ -116,7 +116,7 @@ const SnackGameBizBase = ({ replaceErrorHandler }: Props) => {
   };
 
   const handleStreaksMove = async (): Promise<SnackGameVerify | void> => {
-    const result = await checkMoves(session!.sessionId, cumulativeStreaks);
+    const result = await verifyStreaks(session!.sessionId, cumulativeStreaks);
     cumulativeStreaks = [];
     return result;
   };

--- a/src/pages/games/SnackgameBiz/util/api.ts
+++ b/src/pages/games/SnackgameBiz/util/api.ts
@@ -1,10 +1,12 @@
 import api from '@api/index';
+import { Streak } from '@pages/games/SnackGame/game/snackGame/SnackGameUtil';
 
 import {
   SnackGameDefaultResponse,
   SnackGameEnd,
   SnackGamePause,
   SnackGameStart,
+  SnackGameVerify,
 } from '../../SnackGame/game/game.type';
 
 const GAME_ID = 4;
@@ -15,12 +17,12 @@ export const gameStart = async (): Promise<SnackGameStart> => {
   return data;
 };
 
-export const gameScore = async (
-  score: number,
+export const checkMoves = async (
   sessionId: number,
-): Promise<SnackGameDefaultResponse> => {
-  const { data } = await api.put(`/games/${GAME_ID}/${sessionId}`, {
-    score,
+  streaks: Streak[],
+): Promise<SnackGameVerify> => {
+  const { data } = await api.post(`/games/${GAME_ID}/${sessionId}/streaks`, {
+    streaks,
   });
 
   return data;
@@ -41,8 +43,8 @@ export const gameResume = async (
 };
 
 export type SnackGameBizEnd = {
-  original: SnackGameEnd,
-  signed: string
+  original: SnackGameEnd;
+  signed: string;
 };
 
 export const gameEnd = async (sessionId: number): Promise<SnackGameBizEnd> => {

--- a/src/pages/games/SnackgameBiz/util/api.ts
+++ b/src/pages/games/SnackgameBiz/util/api.ts
@@ -17,7 +17,7 @@ export const gameStart = async (): Promise<SnackGameStart> => {
   return data;
 };
 
-export const checkMoves = async (
+export const verifyStreaks = async (
   sessionId: number,
   streaks: Streak[],
 ): Promise<SnackGameVerify> => {


### PR DESCRIPTION
## 💻 개요

- 신규 피쳐인 척 옛날 피쳐 살리기
- #307

## 📋 변경 및 추가 사항

### 기존
- 게임판은 프론트에서 랜덤 생성한다
- 스트릭 제거 시 그 길이만큼 점수를 올리기 위해 점수 수정 API 요청을 보낸다

### 현재
- 게임판은 서버에서 보내주는 값을 사용한다
- 스트릭 제거 시

  - 일반 스트릭은 `cumulativeStreaks` 배열에 저장한다
  - 황금 스트릭은 지금까지 제거한 모든 스트릭을 넣어서 검증 API 요청을 보낸다 (새 판을 받아와야 해서)<br/><br/>

  > 일시정지와 게임 종료 시, 아직 검증되지 않은 스트릭이 있다면 검증 API 요청을 보낸 후 일시정지/종료합니다!

![verify](https://github.com/user-attachments/assets/c1671644-eb50-473e-b0bf-e1fc1a006d03)

> 아래 항목을 확인할 수 있는 스크린샷입니덩
>
> - 황금 스낵이 없어질 때 `streaks` 요청을 보내는 점
> - 아직 검증되지 않은 스트릭이 있을 때 일시정지하면 검증 -> 일시정지 요청이 가는 점


## 💬 To. 리뷰어

어제까지 한다고 해놓고. 전 거짓말쟁이입니다.