### PR TITLE
feat(SnackgameBiz): 게임 종료화면 제거

### DIFF
--- a/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
+++ b/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
@@ -144,16 +144,7 @@ const SnackGameBizBase = ({ replaceErrorHandler }: Props) => {
     const anyWindow: any = window;
     anyWindow.ReactNativeWebView?.postMessage(JSON.stringify(resultMessage));
 
-    openModal({
-      children: (
-        <GameResult
-          score={data.original.score}
-          percentile={data.original.percentile}
-          reStart={() => application.show(GameScreen)}
-        />
-      ),
-      handleOutsideClick: navigateToLobby,
-    });
+    navigateToLobby()
   };
 
   const navigateToLobby = async () => {


### PR DESCRIPTION
## 💻 개요
- resolves: #309

오랜만의 PR입니다!
이걸 이제야 합니다 ㅎㅎㅎ

<img width="569" alt="image" src="https://github.com/user-attachments/assets/0cd99bfb-046b-4932-8137-97313e36f80d">

고객이 직접 구현할 수 있도록 게임 결과 팝업을 제거합니다.
추후 백오피스 구현된다면 껐다켰다 할 수 있으면 좋겠군요!

## 📋 변경 및 추가 사항
<img src="https://github.com/user-attachments/assets/02d5fd75-558b-4151-93dd-e2893e912d1d" width="400">

- 게임 결과 팝업 제거
