### PR TITLE
fix: CORS 정책 변경으로 타 웹페이지 프레이밍 허용

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,27 @@
 {
-  "rewrites":  [
-    {"source": "/(.*)", "destination": "/"}
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors *"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "ALLOWALL"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## 💻 개요
- resolves: #320 
외부 페이지에 iframe 시 CORS 정책으로 일부 스크립트가 작동하지 않는 문제가 발생하고 있습니다!

> [!CAUTION]
> Blocked a frame with origin "https://an.other.site" from accessing a frame with origin "https://dev.snackga.me". Protocols, domains, and ports must match

## 📋 변경 및 추가 사항
vercel.json 수정, 웹 페이지 응답 헤더에 CORS 및 CSP를 허용 정책을 싣도록 하였습니다.

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
