### PR TITLE
refactor: 스낵게임 Biz 로그인 걷어내기

### DIFF
--- a/src/pages/games/SnackGame/game/screen/GameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/GameScreen.ts
@@ -1,6 +1,11 @@
 import gsap from 'gsap';
 import { Container, Rectangle, Ticker } from 'pixi.js';
 
+import {
+  SnackGameBizStart,
+  SnackGameBizVerify,
+} from '@pages/games/SnackgameBiz/game.type';
+
 import { AppScreen, AppScreenConstructor } from './appScreen';
 import { SnackgameApplication } from './SnackgameApplication';
 import { SnackGameStart, SnackGameVerify } from '../game.type';
@@ -50,8 +55,8 @@ export class GameScreen extends Container implements AppScreen {
     private handleStreak: (
       streak: Streak,
       isGolden: boolean,
-    ) => Promise<SnackGameVerify>,
-    private handleGameStart: () => Promise<SnackGameStart>,
+    ) => Promise<SnackGameVerify | SnackGameBizVerify>,
+    private handleGameStart: () => Promise<SnackGameStart | SnackGameBizStart>,
     private handleGamePause: () => Promise<void>,
     private handleGameEnd: () => Promise<void>,
   ) {

--- a/src/pages/games/SnackGame/game/screen/LobbyScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/LobbyScreen.ts
@@ -30,7 +30,7 @@ export class LobbyScreen extends Container implements AppScreen {
   constructor(
     private app: SnackgameApplication,
     private handleSetMode: (mode: string) => void,
-    private handleNonLoggedInUser: () => Promise<void>,
+    private handleNonLoggedInUser?: () => Promise<void>,
   ) {
     super();
 
@@ -65,7 +65,7 @@ export class LobbyScreen extends Container implements AppScreen {
 
   public handleGameStartButton = async () => {
     try {
-      await this.handleNonLoggedInUser();
+      await this.handleNonLoggedInUser?.();
       this.handleSetMode('default');
       this.app.show(GameScreen);
     } catch (error) {

--- a/src/pages/games/SnackGame/game/snackGame/SnackGame.ts
+++ b/src/pages/games/SnackGame/game/snackGame/SnackGame.ts
@@ -1,5 +1,7 @@
 import { Container } from 'pixi.js';
 
+import { SnackGameBizVerify } from '@pages/games/SnackgameBiz/game.type';
+
 import { Snack } from './Snack';
 import { SnackGameActions } from './SnackGameAction';
 import { SnackGameBoard } from './SnackGameBoard';
@@ -55,7 +57,9 @@ export class SnackGame extends Container {
   public onMatch?: (data: SnackGameOnMatchData) => void;
   /** 보드에서 조각이 팝될 때 발생 */
   public onPop?: (data: SnackGameOnPopData) => void;
-  public onStreak?: (data: Snack[]) => Promise<SnackGameVerify>;
+  public onStreak?: (
+    data: Snack[],
+  ) => Promise<SnackGameVerify | SnackGameBizVerify>;
   /** 게임 시간이 만료되면 발생 */
   public onTimesUp?: () => void;
   /** SnackGameBoard 리셋 시 발생*/

--- a/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
+++ b/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
@@ -70,7 +70,7 @@ const SnackGameBizBase = ({ replaceErrorHandler }: Props) => {
   // TODO: 모드를 타입으로 정의해도 괜찮을 것 같습니다
   const handleGameStart = async () => {
     session = await gameApi.start();
-    gameApi.setAccessToken(session.accessToken);
+    gameApi.setToken(session.token);
     return session;
   };
 
@@ -93,7 +93,10 @@ const SnackGameBizBase = ({ replaceErrorHandler }: Props) => {
   };
 
   const handleStreaksMove = async (): Promise<SnackGameBizVerify> => {
-    const result = await gameApi.verifyStreaks(cumulativeStreaks);
+    const result = await gameApi.verifyStreaks(
+      session!.sessionId,
+      cumulativeStreaks,
+    );
     cumulativeStreaks = [];
     return result;
   };
@@ -104,20 +107,20 @@ const SnackGameBizBase = ({ replaceErrorHandler }: Props) => {
       await handleStreaksMove();
     }
 
-    session = await gameApi.pause();
+    session = await gameApi.pause(session!.sessionId);
   };
 
   const handleGameResume = async () => {
     if (!session) return;
-    session = await gameApi.resume();
+    session = await gameApi.resume(session!.sessionId);
   };
 
   const handleGameEnd = async () => {
     if (cumulativeStreaks.length > 0) {
       await handleStreaksMove();
     }
-    const data = await gameApi.end();
-    gameApi.clearAccessToken();
+    const data = await gameApi.end(session!.sessionId);
+    gameApi.clearToken();
 
     const resultMessage = { type: 'snackgameresult', payload: data };
     window.parent?.postMessage(resultMessage, '*');

--- a/src/pages/games/SnackgameBiz/game.type.ts
+++ b/src/pages/games/SnackgameBiz/game.type.ts
@@ -1,0 +1,19 @@
+import { SnackGameDefaultResponse } from '../SnackGame/game/game.type';
+
+export interface SnackGameBizDefaultResponse
+  extends Omit<SnackGameDefaultResponse, 'sessionId'> {
+  accessToken: string;
+}
+
+export type SnackGameBizStart = SnackGameBizDefaultResponse;
+
+export type SnackGameBizVerify = SnackGameBizDefaultResponse;
+
+export type SnackGameBizPause = SnackGameBizDefaultResponse;
+
+export type SnackGameBizEnd = {
+  original: SnackGameBizDefaultResponse & {
+    percentile: number;
+  };
+  signed: string;
+};

--- a/src/pages/games/SnackgameBiz/game.type.ts
+++ b/src/pages/games/SnackgameBiz/game.type.ts
@@ -1,8 +1,7 @@
 import { SnackGameDefaultResponse } from '../SnackGame/game/game.type';
 
-export interface SnackGameBizDefaultResponse
-  extends Omit<SnackGameDefaultResponse, 'sessionId'> {
-  accessToken: string;
+export interface SnackGameBizDefaultResponse extends SnackGameDefaultResponse {
+  token: string;
 }
 
 export type SnackGameBizStart = SnackGameBizDefaultResponse;

--- a/src/pages/games/SnackgameBiz/util/api.ts
+++ b/src/pages/games/SnackgameBiz/util/api.ts
@@ -13,46 +13,52 @@ import {
 const GAME_ID = 5;
 
 export const createGameApiClient = () => {
-  let accessToken: string | null = null;
+  let token: string | null = null;
 
   const api = axios.create({
     baseURL: import.meta.env.VITE_API_URL,
   });
 
   api.interceptors.request.use((config) => {
-    if (accessToken) {
-      config.headers.Authorization = `${accessToken}`;
+    if (token) {
+      config.headers.Authorization = `${token}`;
     }
     return config;
   });
 
   return {
-    setAccessToken: (token: string) => {
-      accessToken = token;
+    setToken: (newToken: string) => {
+      token = newToken;
     },
-    clearAccessToken: () => {
-      accessToken = null;
+    clearToken: () => {
+      token = null;
     },
     start: async (): Promise<SnackGameBizStart> => {
       const { data } = await api.post(`/games/${GAME_ID}`);
       return data;
     },
-    verifyStreaks: async (streaks: Streak[]): Promise<SnackGameBizVerify> => {
-      const { data } = await api.post(`/games/${GAME_ID}/streaks`, {
-        streaks,
-      });
+    verifyStreaks: async (
+      sessionId: number,
+      streaks: Streak[],
+    ): Promise<SnackGameBizVerify> => {
+      const { data } = await api.post(
+        `/games/${GAME_ID}/${sessionId}/streaks`,
+        {
+          streaks,
+        },
+      );
       return data;
     },
-    pause: async (): Promise<SnackGameBizPause> => {
-      const { data } = await api.post(`games/${GAME_ID}/pause`);
+    pause: async (sessionId: number): Promise<SnackGameBizPause> => {
+      const { data } = await api.post(`games/${GAME_ID}/${sessionId}/pause`);
       return data;
     },
-    resume: async (): Promise<SnackGameBizDefaultResponse> => {
-      const { data } = await api.post(`games/${GAME_ID}/resume`);
+    resume: async (sessionId: number): Promise<SnackGameBizDefaultResponse> => {
+      const { data } = await api.post(`games/${GAME_ID}/${sessionId}/resume`);
       return data;
     },
-    end: async (): Promise<SnackGameBizEnd> => {
-      const { data } = await api.post(`games/${GAME_ID}/end`);
+    end: async (sessionId: number): Promise<SnackGameBizEnd> => {
+      const { data } = await api.post(`games/${GAME_ID}/${sessionId}/end`);
       return data;
     },
   };

--- a/src/pages/games/SnackgameBiz/util/api.ts
+++ b/src/pages/games/SnackgameBiz/util/api.ts
@@ -1,54 +1,59 @@
-import api from '@api/index';
+import axios from 'axios';
+
 import { Streak } from '@pages/games/SnackGame/game/snackGame/SnackGameUtil';
 
 import {
-  SnackGameDefaultResponse,
-  SnackGameEnd,
-  SnackGamePause,
-  SnackGameStart,
-  SnackGameVerify,
-} from '../../SnackGame/game/game.type';
+  SnackGameBizDefaultResponse,
+  SnackGameBizPause,
+  SnackGameBizStart,
+  SnackGameBizVerify,
+  SnackGameBizEnd,
+} from '../game.type';
 
-const GAME_ID = 4;
+const GAME_ID = 5;
 
-export const gameStart = async (): Promise<SnackGameStart> => {
-  const { data } = await api.post(`/games/${GAME_ID}`);
+export const createGameApiClient = () => {
+  let accessToken: string | null = null;
 
-  return data;
-};
-
-export const verifyStreaks = async (
-  sessionId: number,
-  streaks: Streak[],
-): Promise<SnackGameVerify> => {
-  const { data } = await api.post(`/games/${GAME_ID}/${sessionId}/streaks`, {
-    streaks,
+  const api = axios.create({
+    baseURL: import.meta.env.VITE_API_URL,
   });
 
-  return data;
-};
+  api.interceptors.request.use((config) => {
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  });
 
-export const gamePause = async (sessionId: number): Promise<SnackGamePause> => {
-  const { data } = await api.post(`games/${GAME_ID}/${sessionId}/pause`);
-
-  return data;
-};
-
-export const gameResume = async (
-  sessionId: number,
-): Promise<SnackGameDefaultResponse> => {
-  const { data } = await api.post(`games/${GAME_ID}/${sessionId}/resume`);
-
-  return data;
-};
-
-export type SnackGameBizEnd = {
-  original: SnackGameEnd;
-  signed: string;
-};
-
-export const gameEnd = async (sessionId: number): Promise<SnackGameBizEnd> => {
-  const { data } = await api.post(`games/${GAME_ID}/${sessionId}/end`);
-
-  return data;
+  return {
+    setAccessToken: (token: string) => {
+      accessToken = token;
+    },
+    clearAccessToken: () => {
+      accessToken = null;
+    },
+    start: async (): Promise<SnackGameBizStart> => {
+      const { data } = await api.post(`/games/${GAME_ID}`);
+      return data;
+    },
+    verifyStreaks: async (streaks: Streak[]): Promise<SnackGameBizVerify> => {
+      const { data } = await api.post(`/games/${GAME_ID}/streaks`, {
+        streaks,
+      });
+      return data;
+    },
+    pause: async (): Promise<SnackGameBizPause> => {
+      const { data } = await api.post(`games/${GAME_ID}/pause`);
+      return data;
+    },
+    resume: async (): Promise<SnackGameBizDefaultResponse> => {
+      const { data } = await api.post(`games/${GAME_ID}/resume`);
+      return data;
+    },
+    end: async (): Promise<SnackGameBizEnd> => {
+      const { data } = await api.post(`games/${GAME_ID}/end`);
+      return data;
+    },
+  };
 };

--- a/src/pages/games/SnackgameBiz/util/api.ts
+++ b/src/pages/games/SnackgameBiz/util/api.ts
@@ -21,7 +21,7 @@ export const createGameApiClient = () => {
 
   api.interceptors.request.use((config) => {
     if (accessToken) {
-      config.headers.Authorization = `Bearer ${accessToken}`;
+      config.headers.Authorization = `${accessToken}`;
     }
     return config;
   });


### PR DESCRIPTION
## 💻 개요

- 리팩토링
- #322

## 📋 변경 및 추가 사항

![image](https://github.com/user-attachments/assets/e789a285-2bd0-4a1d-9cd3-4b20b7a4e19d)

두 판 해봤는데 잘 되네유

### LobbyScreen의 handleNonLoggedInUser 메서드가 선택 속성으로 변경되었습니다

Biz에서는 로그인이 멸종된 관계로... 하지만 이 한 줄을 위해 Biz용 LobbyScreen을 만들기는 싫엇슴

### Biz 전용 game.type.ts를 생성했습니다

기존 타입에 accessToken을 선택 속성으로 추가해서 폭넓게 사용할 수도 있지만,

1. 일반 게임 API와 Biz API의 차이를 한 눈에 알기 힘들어짐
2. accessToken이 undefined일 수 있어서 별도 처리 필요

로 인해... 똑 떨어트려놨습니다
SnackGame.ts와 GameScreen.ts에도 약간쓰 수정이 생겼으나 감수할 만하다고 띵킹했습니다

### Biz용 api.ts의 구조가 변경되었습니다

sessionId처럼 accessToken을 API 함수 인자로 전달 + 각 API에서 헤더 첨부가 쉬운 방법이긴 하지만은

토큰 관리를 한 곳에 맡기면 함수 인자를 늘리지 않아도 되기 때문에 예전과 비슷한 구조로 고쳐봤어요

혹시 목적에 비해 너무 복잡한 수정이라고 느껴지진 않는지,, 궁금헙니다

## 💬 To. 리뷰어

제가 이해를 잘못 해서 고치느라 수정 커밋이 하나 들어갔는데 못본 척 해주세요
(sessionId가 없어지는 줄 알았음 ㅎㅎ..)
