### PR TITLE
fix: 게임 내 번역 텍스트 수정

### DIFF
--- a/public/locale/en/game.json
+++ b/public/locale/en/game.json
@@ -6,7 +6,7 @@
   "infinite_mode": "Infinite Mode",
 
   "rule": "How to play",
-  "rule_text": "1. Click adjacent snacks to sum 10.\n2. Score points for each snack burst.\n3. Golden snack resets the board",
+  "rule_text": "1. Click adjacent snacks to sum 10.\n2. Score points for each snack burst.\n3. Golden snack resets the board.",
 
   "ready": "Ready...",
   "start": "Start!",
@@ -23,6 +23,6 @@
   "master_volume": "Master",
   "bgm_volume": "Background Music",
   "sfx_volume": "Sound Effects",
-  "haptic": "Haptic",
+  "haptic": "Haptic Feedback",
   "version": "Game version"
 }

--- a/public/locale/en/game.json
+++ b/public/locale/en/game.json
@@ -6,7 +6,7 @@
   "infinite_mode": "Infinite Mode",
 
   "rule": "How to play",
-  "rule_text": "1. Click on adjacent snacks to make a total of 10.\n2. You earn points equal to the number of snacks burst.\n3. Bursting a golden snack resets the game board",
+  "rule_text": "1. Click adjacent snacks to sum 10.\n2. Score points for each snack burst.\n3. Golden snack resets the board",
 
   "ready": "Ready...",
   "start": "Start!",

--- a/public/locale/en/game.json
+++ b/public/locale/en/game.json
@@ -23,5 +23,6 @@
   "master_volume": "Master",
   "bgm_volume": "Background Music",
   "sfx_volume": "Sound Effects",
+  "haptic": "Haptic",
   "version": "Game version"
 }

--- a/public/locale/ko/game.json
+++ b/public/locale/ko/game.json
@@ -23,6 +23,6 @@
   "master_volume": "전체",
   "bgm_volume": "배경음",
   "sfx_volume": "효과음",
-  "haptic": "햅틱",
+  "haptic": "햅틱 피드백",
   "version": "게임 버전"
 }

--- a/public/locale/ko/game.json
+++ b/public/locale/ko/game.json
@@ -23,5 +23,6 @@
   "master_volume": "전체",
   "bgm_volume": "배경음",
   "sfx_volume": "효과음",
+  "haptic": "햅틱",
   "version": "게임 버전"
 }

--- a/src/pages/games/SnackGame/game/legacy/components/GameResult.tsx
+++ b/src/pages/games/SnackGame/game/legacy/components/GameResult.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useRecoilValue } from 'recoil';
 
@@ -24,6 +25,8 @@ interface GameResultProps {
 }
 
 const GameResult = ({ score, percentile, reStart }: GameResultProps) => {
+  const { t } = useTranslation('game');
+
   const { data: profile } = useGetMemberProfile();
   const userStateValue = useRecoilValue(userState);
   const integrateMember = useIntegrateMember();
@@ -48,17 +51,20 @@ const GameResult = ({ score, percentile, reStart }: GameResultProps) => {
   return (
     <div className={'flex w-full flex-grow flex-col justify-evenly gap-4'}>
       <div className={'mx-auto flex flex-col items-center gap-4 font-semibold'}>
-        <p className="text-6xl text-primary">{score}점</p>
+        <p className="text-6xl text-primary">
+          {score}
+          {t('score')}
+        </p>
 
         {userStateValue.type !== 'GUEST' && (
           <>
-            <p>전체 사용자 중 상위 {percentile}%의 점수에요!</p>
+            <p>{t('result_percentile', { percentile })}</p>
             {profile.status && <ExpBarChart status={profile.status} />}
           </>
         )}
 
         <Button onClick={handleReStartButton} size={'lg'}>
-          재시작!
+          {t('restart')}
         </Button>
       </div>
       {userStateValue.type === 'GUEST' && (

--- a/src/pages/games/SnackGame/game/popup/SettingPopup.ts
+++ b/src/pages/games/SnackGame/game/popup/SettingPopup.ts
@@ -104,7 +104,7 @@ export class SettingsPopup extends Container implements AppScreen {
     });
     this.layout.addChild(this.sfxSlider);
 
-    this.hapticCheckBox = new Switch('햅틱');
+    this.hapticCheckBox = new Switch(t('haptic', { ns: 'game' }));
     this.hapticCheckBox.x = 77;
     this.hapticCheckBox.y = 10;
     this.hapticCheckBox.onCheck.connect((v) => {


### PR DESCRIPTION
## 💻 개요

- 이슈 대응
- #337 

## 📋 변경 및 추가 사항

- 텍스트가 팝업을 벗어나지 않게 문구를 간결하게 수정

  ![image](https://github.com/user-attachments/assets/af5f23e6-c259-4304-a2c6-3d6dd71bb472)


- 게임 설정 내 미번역된 부분 수정

  ![image](https://github.com/user-attachments/assets/f9e152b5-88c8-456d-92f9-27c36aa7a53c)

- 게임 결과 내 미번역된 부분 수정

  ![image](https://github.com/user-attachments/assets/a6721e80-a12d-4d8c-9ec0-44f94286fc2b)

## 💬 To. 리뷰어

- "변경없이 재심사" 넣으신 버전이 아마 통과된 걸로 보이는데 맞나요..? (지금 스토어에 올라간 1.2.1 (2) 버전)

  - 제가 확인해보려고 Apple Developer 로그인 때렸다가, , , 맞다 내 번호가 아니지, , , 했습니다
  인증번호 문자가 갔을텐데 제가 범인입니다

  - 바로 머지하려다가 메일 상으로 가장 최근 상태가 `ready for distribution` 이길래 일단,, 냅두겠으빈다
