### PR TITLE
fix: Biz 환경에서 getMemberProfile 호출 방지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,10 +61,16 @@ const App = () => {
 
   useEffect(() => {
     const updateProfile = async () => {
-      const profile = await getMemberProfile();
-      setUserState({ ...profile });
+      try {
+        const profile = await getMemberProfile();
+        setUserState({ ...profile });
+      } catch (e) {
+        resetUser();
+        deleteUserPersistState();
+      }
     };
 
+    if (window.location.pathname.includes('biz')) return;
     updateProfile();
 
     // const checkUserExpired = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
-import { useRecoilState, useResetRecoilState } from 'recoil';
+import { useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { getMemberProfile } from '@api/members.api';
 import ErrorBoundary from '@components/base/ErrorBoundary';
@@ -12,7 +12,6 @@ import GameLayout from '@pages/GameLayout';
 import { PrivateRoute } from '@pages/PrivateRoute';
 import { resetUserState, userState } from '@utils/atoms/member.atom';
 
-import { LOCAL_STORAGE_KEY } from '@constants/localStorage.constant';
 import PATH from '@constants/path.constant';
 import useLocalStorage from '@hooks/useLocalStorage';
 
@@ -49,11 +48,8 @@ const WithdrawPage = lazy(() => import('@pages/withdraw/WithdrawPage'));
 const NoticePage = lazy(() => import('@pages/user/notice/NoticePage'));
 
 const App = () => {
-  const [userStateValue, setUserState] = useRecoilState(userState);
+  const setUserState = useSetRecoilState(userState);
   const resetUser = useResetRecoilState(resetUserState);
-  const { storageValue, deleteStorageValue } = useLocalStorage<string>({
-    key: LOCAL_STORAGE_KEY.USER_EXPIRE_TIME,
-  });
   const { deleteStorageValue: deleteUserPersistState } =
     useLocalStorage<string>({
       key: 'userPersistState',
@@ -72,22 +68,6 @@ const App = () => {
 
     if (window.location.pathname.includes('biz')) return;
     updateProfile();
-
-    // const checkUserExpired = () => {
-    //   if (!storageValue) return;
-
-    //   const currentTime = Date.now();
-    //   const oneMonthInMilliseconds = 30 * 24 * 60 * 60 * 1000;
-    //   const expireTime = parseInt(storageValue, 10);
-
-    //   if (expireTime && currentTime - expireTime > oneMonthInMilliseconds) {
-    //     resetUser();
-    //     deleteUserPersistState();
-    //     deleteStorageValue();
-    //   }
-    // };
-
-    // checkUserExpired();
   }, []);
 
   return (

--- a/src/components/Auth/OAuth.tsx
+++ b/src/components/Auth/OAuth.tsx
@@ -12,9 +12,7 @@ import { MemberType } from '@utils/types/member.type';
 import { isApp, isIOSApp } from '@utils/userAgentIdentifier';
 
 import { QUERY_KEY } from '@constants/api.constant';
-import { LOCAL_STORAGE_KEY } from '@constants/localStorage.constant';
 import PATH from '@constants/path.constant';
-import useLocalStorage from '@hooks/useLocalStorage';
 import useToast from '@hooks/useToast';
 
 interface DialogProps {
@@ -29,9 +27,6 @@ interface OAuthContainerProps {
 const OAuth = ({ oAuthOnSuccess }: OAuthContainerProps) => {
   const { t } = useTranslation();
   const [popup, setPopup] = useState<boolean>(false);
-  const { setStorageValue } = useLocalStorage({
-    key: LOCAL_STORAGE_KEY.USER_EXPIRE_TIME,
-  });
 
   const setUserState = useSetRecoilState(userState);
   const openToast = useToast();
@@ -70,7 +65,6 @@ const OAuth = ({ oAuthOnSuccess }: OAuthContainerProps) => {
     setUserState(() => ({
       ...member,
     }));
-    setStorageValue(Date.now());
 
     queryClient.invalidateQueries({ queryKey: [QUERY_KEY.USER_PROFILE] });
   };

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -14,9 +14,7 @@ import RouterLink from '@components/RouterLink/RouterLink';
 import Spacing from '@components/Spacing/Spacing';
 import { resetUserState, userState } from '@utils/atoms/member.atom';
 
-import { LOCAL_STORAGE_KEY } from '@constants/localStorage.constant';
 import PATH from '@constants/path.constant';
-import useLocalStorage from '@hooks/useLocalStorage';
 import useModal from '@hooks/useModal';
 import useToast from '@hooks/useToast';
 
@@ -34,9 +32,6 @@ const Header = ({ children, className }: HeaderProps) => {
   const userInfo = useRecoilValue(userState);
   const navigate = useNavigate();
   const [isToggleOpen, setIsToggleOpen] = useState(false);
-  const { deleteStorageValue } = useLocalStorage({
-    key: LOCAL_STORAGE_KEY.USER_EXPIRE_TIME,
-  });
 
   const handleLogin = () => {
     openModal({
@@ -48,7 +43,6 @@ const Header = ({ children, className }: HeaderProps) => {
     resetUser();
     await logOut();
     openToast(t('login_logout'), 'success');
-    deleteStorageValue();
     navigate(PATH.MAIN, { replace: true });
   };
 

--- a/src/constants/localStorage.constant.ts
+++ b/src/constants/localStorage.constant.ts
@@ -1,5 +1,4 @@
 export const LOCAL_STORAGE_KEY = {
-  USER_EXPIRE_TIME: 'userExpireTime',
   LANGUAGE_CHANGE: 'languageChange',
 };
 

--- a/src/hooks/queries/auth.query.ts
+++ b/src/hooks/queries/auth.query.ts
@@ -9,8 +9,6 @@ import { userState } from '@utils/atoms/member.atom';
 import { MemberType } from '@utils/types/member.type';
 
 import { ServerError } from '@constants/api.constant';
-import { LOCAL_STORAGE_KEY } from '@constants/localStorage.constant';
-import useLocalStorage from '@hooks/useLocalStorage';
 import useModal from '@hooks/useModal';
 import useToast from '@hooks/useToast';
 
@@ -23,15 +21,11 @@ const useMemberOnSuccess = () => {
   const openToast = useToast();
   const setUserState = useSetRecoilState(userState);
   const { closeModal } = useModal();
-  const { setStorageValue } = useLocalStorage({
-    key: LOCAL_STORAGE_KEY.USER_EXPIRE_TIME,
-  });
 
   return (member: MemberType) => {
     setUserState(() => ({
       ...member,
     }));
-    setStorageValue(Date.now());
     openToast(t('guest_login_success'), 'success');
     closeModal();
   };

--- a/src/pages/user/setting/SettingPage.tsx
+++ b/src/pages/user/setting/SettingPage.tsx
@@ -7,9 +7,7 @@ import { logOut } from '@api/auth.api';
 import TopBar from '@components/TopBar/TopBar';
 import { resetUserState, userState } from '@utils/atoms/member.atom';
 
-import { LOCAL_STORAGE_KEY } from '@constants/localStorage.constant';
 import PATH from '@constants/path.constant';
-import useLocalStorage from '@hooks/useLocalStorage';
 import useToast from '@hooks/useToast';
 
 import LanguageSelect from './components/LanguageSelect';
@@ -23,15 +21,11 @@ const SettingPage = () => {
 
   const openToast = useToast();
   const navigate = useNavigate();
-  const { deleteStorageValue } = useLocalStorage({
-    key: LOCAL_STORAGE_KEY.USER_EXPIRE_TIME,
-  });
 
   const handleLogout = async () => {
     resetUser();
     await logOut();
     openToast(t('login_logout'), 'success');
-    deleteStorageValue();
     window.dispatchEvent(new Event('loggedOut'));
     navigate(PATH.SNACK_GAME, { replace: true });
   };

--- a/src/pages/withdraw/WithdrawPage.tsx
+++ b/src/pages/withdraw/WithdrawPage.tsx
@@ -9,10 +9,8 @@ import Button from '@components/Button/Button';
 import TopBar from '@components/TopBar/TopBar';
 import { resetUserState } from '@utils/atoms/member.atom';
 
-import { LOCAL_STORAGE_KEY } from '@constants/localStorage.constant';
 import PATH from '@constants/path.constant';
 import { useDeleteMember } from '@hooks/queries/members.query';
-import useLocalStorage from '@hooks/useLocalStorage';
 import useToast from '@hooks/useToast';
 
 const warningTextKey = ['ranking_deleted', 'history_deleted', 'level_reset'];
@@ -26,15 +24,11 @@ const WithdrawPage = () => {
   const navigate = useNavigate();
   const openToast = useToast();
   const { t } = useTranslation('withdraw');
-  const { deleteStorageValue } = useLocalStorage({
-    key: LOCAL_STORAGE_KEY.USER_EXPIRE_TIME,
-  });
 
   const handleWithdraw = async () => {
     resetUser();
     await withdrawMember.mutateAsync();
     openToast(t('withdraw_success'), 'success');
-    deleteStorageValue();
     window.dispatchEvent(new Event('loggedOut'));
     navigate(PATH.SNACK_GAME, { replace: true });
   };


### PR DESCRIPTION
## 💻 개요

- 버그 픽스
- #347 

## 📋 변경 및 추가 사항

- window.location으로 현재 url을 판단해서 'biz'가 포함되어 있으면 조기 종료

- 이외에는 기존 동작과 동일하게 updateProfile() 호출 ➡️ 에러 생기면 전역 상태 초기화 & 삭제

- 사용하지 않는 스토리지 값 관련 코드 제거 (LOCAL_STORAGE_KEY.USER_EXPIRE_TIME)

  - 원래 App.tsx에서 쓰다가 주석 처리해놔서 사실 세팅/삭제만 하고 아무데서도 안 쓰고 있슴 

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
