### PR TITLE
fix: 도발 대상이 없을 때 ProvocationSender를 노출하지 않는다

### DIFF
--- a/src/api/history.api.ts
+++ b/src/api/history.api.ts
@@ -1,10 +1,10 @@
-import { GameHistoryResponse } from '@utils/types/common.type';
+import { GameHistoryResponse } from '@utils/types/history.type';
 
 import api from './index';
 
-
-export const getGameHistory = async  (by: string): Promise<GameHistoryResponse[]> => {
-    const { data } = await api.get(`/histories/me?by=${by}`);
-    return data.reverse();
-}
-
+export const getGameHistory = async (
+  by: string,
+): Promise<GameHistoryResponse[]> => {
+  const { data } = await api.get(`/histories/me?by=${by}`);
+  return data.reverse();
+};

--- a/src/api/ranking.api.ts
+++ b/src/api/ranking.api.ts
@@ -3,7 +3,7 @@ import {
   RankingType,
   RankingViewType,
   SeasonType,
-} from '@utils/types/common.type';
+} from '@utils/types/ranking.type';
 
 export const totalRanking = async (gameId: RankingViewType) => {
   const { data } = await api.get(`/rankings/${gameId}?by=BEST_SCORE`);

--- a/src/hooks/queries/history.query.ts
+++ b/src/hooks/queries/history.query.ts
@@ -2,7 +2,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import { getGameHistory } from '@api/history.api';
-import { GameHistoryResponse } from '@utils/types/common.type';
+import { GameHistoryResponse } from '@utils/types/history.type';
 
 import { QUERY_KEY } from '@constants/api.constant';
 

--- a/src/hooks/queries/ranking.query.ts
+++ b/src/hooks/queries/ranking.query.ts
@@ -13,7 +13,7 @@ import {
   RankingType,
   RankingViewType,
   SeasonType,
-} from '@utils/types/common.type';
+} from '@utils/types/ranking.type';
 
 import { QUERY_KEY, ServerError } from '@constants/api.constant';
 

--- a/src/hooks/useCanvasOffset.ts
+++ b/src/hooks/useCanvasOffset.ts
@@ -1,8 +1,13 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { canvasOffsetType } from '@utils/types/common.type';
-
 import useDebouncedCallback from '@hooks/useDebouncedCallback';
+
+interface canvasOffsetType {
+  offsetWidth: number;
+  offsetHeight: number;
+  offsetLeft: number;
+  offsetTop: number;
+}
 
 export const useCanvasOffset = () => {
   const canvasBaseRef = useRef<HTMLDivElement>(null);

--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -165,21 +165,24 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
     const isGuest =
       JSON.parse(window.localStorage.getItem(ATOM_KEY.USER_PERSIST) || '{}')
         .userState.type === 'GUEST';
-
     if (isGuest) {
       return navigateToLobby();
     }
 
     const canProvoke = await pollProvoke();
-    if (canProvoke) {
-      const targets = await getSurpassedPlayers();
-      openModal({
-        children: <ProvocationSender targets={targets} />,
-        onClose: navigateToLobby,
-      });
+    if (!canProvoke) {
+      return navigateToLobby();
     }
 
-    return navigateToLobby();
+    const targets = await getSurpassedPlayers();
+    if (targets.length === 0) {
+      return navigateToLobby();
+    }
+
+    return openModal({
+      children: <ProvocationSender targets={targets} />,
+      onClose: navigateToLobby,
+    });
   };
 
   const pollProvoke = async (): Promise<boolean> => {

--- a/src/pages/games/SnackGame/game/components/ProvocationSender.tsx
+++ b/src/pages/games/SnackGame/game/components/ProvocationSender.tsx
@@ -6,14 +6,9 @@ import { useRecoilValue } from 'recoil';
 import Button from '@components/Button/Button';
 import Spacing from '@components/Spacing/Spacing';
 import { userState } from '@utils/atoms/member.atom';
+import { ProvocationTarget } from '@utils/types/common.type';
 
 import { useSendProvocation } from '@hooks/queries/provocation.query';
-
-interface ProvocationTarget {
-  name: string;
-  beforeRank: number;
-  currentRank: number;
-}
 
 const ProvocationSender = ({ targets }: { targets: ProvocationTarget[] }) => {
   const { t } = useTranslation('game');

--- a/src/pages/games/SnackGame/game/components/ProvocationSender.tsx
+++ b/src/pages/games/SnackGame/game/components/ProvocationSender.tsx
@@ -6,9 +6,10 @@ import { useRecoilValue } from 'recoil';
 import Button from '@components/Button/Button';
 import Spacing from '@components/Spacing/Spacing';
 import { userState } from '@utils/atoms/member.atom';
-import { ProvocationTarget } from '@utils/types/common.type';
 
 import { useSendProvocation } from '@hooks/queries/provocation.query';
+
+import { ProvocationTarget } from '../game.type';
 
 const ProvocationSender = ({ targets }: { targets: ProvocationTarget[] }) => {
   const { t } = useTranslation('game');

--- a/src/pages/games/SnackGame/game/game.type.ts
+++ b/src/pages/games/SnackGame/game/game.type.ts
@@ -29,3 +29,9 @@ export type SnackGamePause = SnackGameDefaultResponse;
 export type SnackGameEnd = SnackGameDefaultResponse & {
   percentile: number;
 };
+
+export type ProvocationTarget = {
+  name: string;
+  beforeRank: number;
+  currentRank: number;
+};

--- a/src/pages/games/SnackGame/game/util/provocation.api.ts
+++ b/src/pages/games/SnackGame/game/util/provocation.api.ts
@@ -1,6 +1,7 @@
 import { AxiosResponse } from 'axios';
 
 import api from '@api/index';
+import { ProvocationTarget } from '@utils/types/common.type';
 
 export const canProvoke = async (
   ownerId: number,
@@ -11,7 +12,7 @@ export const canProvoke = async (
   return response;
 };
 
-export const getSurpassedPlayers = async () => {
+export const getSurpassedPlayers = async (): Promise<ProvocationTarget[]> => {
   const { data } = await api.get('rankings/histories');
 
   return data;

--- a/src/pages/games/SnackGame/game/util/provocation.api.ts
+++ b/src/pages/games/SnackGame/game/util/provocation.api.ts
@@ -1,7 +1,8 @@
 import { AxiosResponse } from 'axios';
 
 import api from '@api/index';
-import { ProvocationTarget } from '@utils/types/common.type';
+
+import { ProvocationTarget } from '../game.type';
 
 export const canProvoke = async (
   ownerId: number,

--- a/src/pages/games/SnackGame/ranking/RankingPage.tsx
+++ b/src/pages/games/SnackGame/ranking/RankingPage.tsx
@@ -8,7 +8,7 @@ import RetryError from '@components/Error/RetryError';
 import Spacing from '@components/Spacing/Spacing';
 import { Tab, TabOptionType } from '@components/Tab/Tab';
 import RankingSection from '@pages/games/SnackGame/ranking/components/RankingSection';
-import { RankingViewType } from '@utils/types/common.type';
+import { RankingViewType } from '@utils/types/ranking.type';
 
 import { useGetSeasons } from '@hooks/queries/ranking.query';
 

--- a/src/pages/games/SnackGame/ranking/components/OtherRanking.tsx
+++ b/src/pages/games/SnackGame/ranking/components/OtherRanking.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
 
 import { Level } from '@components/Level/Level';
-import { RankingType } from '@utils/types/common.type';
+import { RankingType } from '@utils/types/ranking.type';
 
 interface OtherRankingProps {
   otherRanking: RankingType[];

--- a/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
+++ b/src/pages/games/SnackGame/ranking/components/RankingSection.tsx
@@ -9,7 +9,7 @@ import Spacing from '@components/Spacing/Spacing';
 import OtherRanking from '@pages/games/SnackGame/ranking/components/OtherRanking';
 import TopRanking from '@pages/games/SnackGame/ranking/components/TopRanking';
 import { userState } from '@utils/atoms/member.atom';
-import { GameSeasonProps } from '@utils/types/common.type';
+import { GameSeasonProps } from '@utils/types/ranking.type';
 
 import {
   useGetSeasonRanking,

--- a/src/pages/games/SnackGame/ranking/components/TopRanking.tsx
+++ b/src/pages/games/SnackGame/ranking/components/TopRanking.tsx
@@ -10,7 +10,7 @@ import Third from '@assets/images/third.avif';
 import ThirdWebp from '@assets/images/third.webp';
 import ImageWithFallback from '@components/ImageWithFallback/ImageWithFallback';
 import { Level } from '@components/Level/Level';
-import { RankingType } from '@utils/types/common.type';
+import { RankingType } from '@utils/types/ranking.type';
 
 interface TopRankingProps {
   topRanking: RankingType[];

--- a/src/pages/games/SnackGame/ranking/components/UserRanking.tsx
+++ b/src/pages/games/SnackGame/ranking/components/UserRanking.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Level } from '@components/Level/Level';
 import Spacing from '@components/Spacing/Spacing';
-import { GameSeasonProps } from '@utils/types/common.type';
+import { GameSeasonProps } from '@utils/types/ranking.type';
 
 import {
   useGetSeasonRankingMe,

--- a/src/pages/user/components/ChartSection.tsx
+++ b/src/pages/user/components/ChartSection.tsx
@@ -5,7 +5,7 @@ import QueryBoundary from '@components/base/QueryBoundary';
 import RetryError from '@components/Error/RetryError';
 import Spacing from '@components/Spacing/Spacing';
 import { Tab, TabOptionType } from '@components/Tab/Tab';
-import { HistoryViewType } from '@utils/types/common.type';
+import { HistoryViewType } from '@utils/types/history.type';
 
 import { HistoryLineChart } from './HistoryLineChart';
 

--- a/src/pages/user/components/HistoryLineChart.tsx
+++ b/src/pages/user/components/HistoryLineChart.tsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
 } from 'chart.js';
 
-import { HistoryViewType } from '@utils/types/common.type';
+import { HistoryViewType } from '@utils/types/history.type';
 
 import { useGetGameHistory } from '@hooks/queries/history.query';
 

--- a/src/utils/types/common.type.ts
+++ b/src/utils/types/common.type.ts
@@ -63,3 +63,9 @@ export type NoticeItemType = {
   description: string;
   date: string;
 };
+
+export type ProvocationTarget = {
+  name: string;
+  beforeRank: number;
+  currentRank: number;
+};

--- a/src/utils/types/common.type.ts
+++ b/src/utils/types/common.type.ts
@@ -1,71 +1,16 @@
 import React from 'react';
 
-import { MemberType } from '@utils/types/member.type';
-
-import { SnackGameId } from '@constants/common.constant';
-
-export type ToastType = 'success' | 'error' | 'loading' | 'info' | 'warning';
-
 export interface ModalType {
   open?: boolean;
   children?: React.ReactNode;
   onClose?: () => void;
 }
 
+export type ToastType = 'success' | 'error' | 'loading' | 'info' | 'warning';
 export interface toastStateType {
   id?: string;
   message: string;
   type: ToastType;
 }
 
-export type RankingViewType = (typeof SnackGameId)[keyof typeof SnackGameId];
-
-export interface GameSeasonProps {
-  season: number;
-  gameId: RankingViewType;
-}
-
-export type RankingType = {
-  rank: number;
-  owner: MemberType;
-  score: number;
-  message?: string;
-};
-
-export type SeasonType = {
-  id: number;
-  name: string;
-  startedAt: string;
-  endedAt: string | null;
-};
-
 export type MouseEventType = React.MouseEvent<HTMLCanvasElement> | TouchEvent;
-
-export interface canvasOffsetType {
-  offsetWidth: number;
-  offsetHeight: number;
-  offsetLeft: number;
-  offsetTop: number;
-}
-
-export interface GameHistoryResponse {
-  sessionId: number;
-  memberId: number;
-  score: number;
-  updatedAt: string;
-}
-
-export type HistoryViewType = 'DATE' | 'SESSION';
-
-export type NoticeItemType = {
-  id: number;
-  title: string;
-  description: string;
-  date: string;
-};
-
-export type ProvocationTarget = {
-  name: string;
-  beforeRank: number;
-  currentRank: number;
-};

--- a/src/utils/types/history.type.ts
+++ b/src/utils/types/history.type.ts
@@ -1,0 +1,8 @@
+export interface GameHistoryResponse {
+  sessionId: number;
+  memberId: number;
+  score: number;
+  updatedAt: string;
+}
+
+export type HistoryViewType = 'DATE' | 'SESSION';

--- a/src/utils/types/ranking.type.ts
+++ b/src/utils/types/ranking.type.ts
@@ -1,0 +1,24 @@
+import { MemberType } from '@utils/types/member.type';
+
+import { SnackGameId } from '@constants/common.constant';
+
+export type RankingViewType = (typeof SnackGameId)[keyof typeof SnackGameId];
+
+export interface GameSeasonProps {
+  season: number;
+  gameId: RankingViewType;
+}
+
+export type RankingType = {
+  rank: number;
+  owner: MemberType;
+  score: number;
+  message?: string;
+};
+
+export type SeasonType = {
+  id: number;
+  name: string;
+  startedAt: string;
+  endedAt: string | null;
+};


### PR DESCRIPTION
## 💻 개요

- 버그 픽스 겸 리팩토링. . . 
- #349 

## 📋 변경 및 추가 사항

- ~그러면 곤란하지만~ 도발 대상이 담긴 targets 배열이 빈 배열이라면 모달 띄우지 않음

- common.type.ts에 있던 타입을 도메인별로 분리

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
