### PR TITLE
feat: targets이 빈 배열이면 Sentry에 기록한다

### DIFF
--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 
+import * as Sentry from '@sentry/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 
@@ -176,6 +177,10 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
 
     const targets = await getSurpassedPlayers();
     if (targets.length === 0) {
+      Sentry.captureMessage(
+        `[🚨 ${import.meta.env.VITE_NODE_ENV}경고]: targets 배열이 비어있습니다. sessionId: ${session!.sessionId}`,
+        'error',
+      );
       return navigateToLobby();
     }
 


### PR DESCRIPTION
## 💻 개요

- #349 의 연장선. . . 
- 신규 피처

## 📋 변경 및 추가 사항

> 목록(targets)이 있는데 못 띄운건지 진짜 목록이 빈 배열인지 구분이 안 가서

- 를 구분하기 위해 targets이 빈 배열로 오는 경우는 센트리에 해당 세션 ID를 기록하려고 함

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
