### PR TITLE
fix: 랜딩 페이지 확대 시 UI 깨짐

### DIFF
--- a/src/pages/main/components/HeroSection.tsx
+++ b/src/pages/main/components/HeroSection.tsx
@@ -103,12 +103,8 @@ const HeroSection = () => {
   const [selected, setSelected] = useState<number>(0);
 
   return (
-    <section
-      className={
-        'flex h-screen flex-col bg-primary py-12 landscape:min-h-screen '
-      }
-    >
-      <div className={'flex h-full grow bg-white'}>
+    <section className={'flex min-h-screen flex-col bg-primary pb-12 pt-16'}>
+      <div className={'flex h-full grow bg-white pt-4'}>
         <Hero {...heroContents[selected]} />
       </div>
       <div


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 이슈 대응
- #355 

## 📋 변경 및 추가 사항

- `<HeroSection>` `py-12`를 `pt-16` & `pb-12`로 분리

  - 위쪽 패딩(12)이 헤더 높이(16)보다 작아서 확대 시 헤더가 컨텐츠를 약간. 가렸음

    ![image](https://github.com/user-attachments/assets/e05e5dd0-e6e2-454a-a008-d0c958f90b6e)


  - 아래쪽 패딩은 12로 유지

    | 전 | 후 |
    | -- | -- |
    | ![image](https://github.com/user-attachments/assets/1e590b41-96bc-4a4b-b7ef-4e21d076bcee) | ![image](https://github.com/user-attachments/assets/8b53f0ba-bea7-4907-9f26-cdc8570ed1e6) |
 
    - 이 상황에서 헤더 - 콘텐츠 사이 여백을 위해 흰색 영역에 `pt-4` 추가

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->

- 150%~ 배율부터는 h-screen 포기