### PR TITLE
feat: 일회성 모달 구현

### DIFF
--- a/src/constants/localStorage.constant.ts
+++ b/src/constants/localStorage.constant.ts
@@ -11,3 +11,4 @@ export const KEY_PREFIX_STATS = 'stats-';
 export const KEY_PREFIX_BEST_SCORE = 'stats-best-score-';
 export const KEY_GAME_MODE = 'game-mode';
 export const KEY_GAME_SETTINGS = 'game-settings';
+export const KEY_LAST_NOTICE_INFO = 'lastNoticeInfo';

--- a/src/pages/games/SnackGame/game/SnackGamePage.tsx
+++ b/src/pages/games/SnackGame/game/SnackGamePage.tsx
@@ -1,15 +1,22 @@
+import { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 
 import ErrorBoundary from '@components/base/ErrorBoundary';
 import RetryError from '@components/Error/RetryError';
-
-import SnackGameBase from './SnackGameBase';
+import { useNoticeModal } from '@pages/games/SnackGame/game/hook/useNoticeModal';
+import SnackGameBase from '@pages/games/SnackGame/game/SnackGameBase';
 
 const SnackGamePage = () => {
   let errorHandler = () => {
     console.log('SnackgameBase 초기화 전 오류가 발생했습니다');
   };
   const replaceErrorHandler = (handler: () => void) => (errorHandler = handler);
+
+  const { openNoticeModal } = useNoticeModal();
+
+  useEffect(() => {
+    openNoticeModal();
+  }, []);
 
   return (
     <>

--- a/src/pages/games/SnackGame/game/hook/useNoticeModal.tsx
+++ b/src/pages/games/SnackGame/game/hook/useNoticeModal.tsx
@@ -1,0 +1,64 @@
+import Button from '@components/Button/Button';
+
+import { KEY_LAST_NOTICE_INFO } from '@constants/localStorage.constant';
+import useModal from '@hooks/useModal';
+
+// notice_YYYYMMDD_keyword(_version)
+const CURRENT_ID = 'notice_20250608_keyword';
+
+const Notice = () => {
+  const { closeModal } = useModal();
+
+  const hideForToday = () => {
+    const ONE_DAY = 24 * 60 * 60 * 1000;
+
+    localStorage.setItem(
+      KEY_LAST_NOTICE_INFO,
+      JSON.stringify({
+        id: CURRENT_ID,
+        hideUntil: new Date(Date.now() + ONE_DAY),
+      }),
+    );
+    closeModal();
+  };
+
+  return (
+    <div className={'flex w-full flex-grow flex-col justify-between gap-4'}>
+      <div className="flex-grow">notice content</div>
+      <div className="flex w-full justify-between gap-2 md:justify-evenly">
+        <Button
+          onClick={hideForToday}
+          size={'lg'}
+          style={'border'}
+          className="text-md"
+        >
+          하루 동안 숨기기
+        </Button>
+        <Button onClick={closeModal} size={'lg'} className="text-md">
+          닫기
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export const useNoticeModal = () => {
+  const { openModal } = useModal();
+
+  const isNoticeHidden = () => {
+    const lastNotice = localStorage.getItem(KEY_LAST_NOTICE_INFO);
+    const { id, hideUntil } = lastNotice ? JSON.parse(lastNotice) : {};
+
+    return id === CURRENT_ID && new Date(hideUntil) > new Date();
+  };
+
+  const openNoticeModal = () => {
+    if (isNoticeHidden()) return;
+
+    openModal({
+      children: <Notice />,
+    });
+  };
+
+  return { openNoticeModal };
+};


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 신규 피처
- #352 

## 📋 변경 및 추가 사항

- (주로) 공지사항 노출용 일회성 모달 구현

  - useNoticeModal = openModal 호출 전에 날짜 처리만 추가된 훅입니다
  - localStorage에 최근 공지 ID & 날짜를 저장해서 비교합니다

    - 만약 공지 ID가 바뀌거나
    - (공지 ID는 그대로지만) hideUntil 시각이 지나지 않았다면 모달을 노출하지 않습니다
    
  ![modal](https://github.com/user-attachments/assets/a5ff7db1-c9e4-451d-bacd-d26f9191b771)

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->

- 공지 모달을 연달아 여러 개 띄울 상황은 아직 없어서 일단 하나만 뜬다고 가정하고 구현
  (공지 내용은 `<Notice>`에 들어감 ➡️ 공지 바뀔 때마다 수정)
