### PR TITLE
fix: pnpm onlyBuiltDependencies 옵션 추가

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+onlyBuiltDependencies:
+  - core-js
+  - esbuild
+  - sharp
+  - ttf2woff2
+  - unrs-resolver


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 이슈대응
- #358  

## 📋 변경 및 추가 사항

- `pnpm approve-builds` 명령어를 실행해서 라이브러리의 lifecycle script를 실행하도록 함
- pnpm-workspace.yaml은 위 명령어 실행 후 자동으로 생성된 파일

- 작업 후 기존에 동작하지 않던 AssetsPack 스크립트가 다시 정상적으로 동작하는 점 확인 👀 

  ![image](https://github.com/user-attachments/assets/802cd53e-6c42-47e8-ba95-c68cf5c1d26c)


## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
