### PR TITLE
fix: 랭킹 페이지에서 과거 공지가 보이는 문제

### DIFF
--- a/src/hooks/queries/notice.query.ts
+++ b/src/hooks/queries/notice.query.ts
@@ -2,7 +2,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getNoticeXML } from '@api/notice.api';
 
-const parseXML = (xmlText: string) => {
+const parseNoticeTitleFromXML = (xmlText: string) => {
   const parser = new DOMParser();
   const xmlDoc = parser.parseFromString(xmlText, 'application/xml');
   const items = xmlDoc.getElementsByTagName('item');
@@ -27,7 +27,7 @@ export const useGetNotices = () => {
     queryKey: ['notices'],
     queryFn: async () => {
       const data = await getNoticeXML();
-      return parseXML(data);
+      return parseNoticeTitleFromXML(data);
     },
   });
   return data;

--- a/src/hooks/queries/notice.query.ts
+++ b/src/hooks/queries/notice.query.ts
@@ -5,7 +5,21 @@ import { getNoticeXML } from '@api/notice.api';
 const parseXML = (xmlText: string) => {
   const parser = new DOMParser();
   const xmlDoc = parser.parseFromString(xmlText, 'application/xml');
-  return xmlDoc.getElementsByTagName('title');
+  const items = xmlDoc.getElementsByTagName('item');
+
+  const notices = Array.from(items).map((item) => {
+    const title = item.getElementsByTagName('title')[0]?.textContent ?? '';
+    const pubDate = item.getElementsByTagName('pubDate')[0]?.textContent ?? '';
+    return { title, pubDate };
+  });
+
+  notices.sort((a, b) => {
+    const dateA = new Date(a.pubDate).getTime();
+    const dateB = new Date(b.pubDate).getTime();
+    return dateA - dateB;
+  });
+
+  return notices.map((n) => n.title);
 };
 
 export const useGetNotices = () => {

--- a/src/pages/games/SnackGame/ranking/components/NoticeSection.tsx
+++ b/src/pages/games/SnackGame/ranking/components/NoticeSection.tsx
@@ -16,7 +16,7 @@ export const NoticeSection = () => {
     >
       <NoticeIcon className="h-[16px] w-[16px] shrink-0 text-primary" />
       <p className="overflow-hidden text-ellipsis whitespace-nowrap text-sm text-primary-deep-dark">
-        {noticeTitles[noticeTitles.length - 1].textContent}
+        {noticeTitles[noticeTitles.length - 1]}
       </p>
     </div>
   );


### PR DESCRIPTION
## 💻 개요

- 이슈 대응
- #375 


## 📋 변경 및 추가 사항

- 공지 데이터 (xml) 을 파싱할 때 날짜 (`<pubDate>`) 기준으로 정렬합니다

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
