### PR TITLE
feat(SnackGameBase): 피버타임 중에는 스트릭 발생 시마다 검증 요청을 보낸다

### DIFF
--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -135,7 +135,7 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
   const handleStreak = async (streak: StreakWithMeta, isGolden: boolean) => {
     cumulativeStreaks = [...cumulativeStreaks, streak];
 
-    if (isGolden) {
+    if (isGolden || streak.isFever) {
       session = await handleStreaksMove();
     }
     return session!;


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 신규 피처 (인데 아직 완성 전임)

## 📋 변경 및 추가 사항

- 피버타임 중에는 스트릭을 누적시키지 않고 바로바로 검증 요청을 쏘도록 수정했습니다

  > [26/01/12 회의](https://www.notion.so/26-01-12-2e600ca278ab801aae3ee95949124a4e?source=copy_link)에서 결정했던 내용이에용
  
  | 피버타임 아닐 때 | 피버타임일 때 (new) |
  |:---:|:---:|
  |![피버 아닐 땐 골든일 때만 요청](https://github.com/user-attachments/assets/f63d5726-2b59-44c2-9e0a-f23615f70137)|![피버일 떈 무조건 ㄱㄱ](https://github.com/user-attachments/assets/2ff17378-d174-4b28-89c7-0bdab195ea52)|
  |동일 (스트릭 누적 ➡️ 황금 스낵 제거 시 한 번에 검증 요청) | 스트릭 제거될 때마다 검증 요청 |

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
