### PR TITLE
feat: 피버타임 아이템 구현 마무리

### DIFF
--- a/src/pages/games/SnackGame/game/SnackGameBase.tsx
+++ b/src/pages/games/SnackGame/game/SnackGameBase.tsx
@@ -135,7 +135,7 @@ const SnackGameBase = ({ replaceErrorHandler }: Props) => {
   const handleStreak = async (streak: StreakWithMeta, isGolden: boolean) => {
     cumulativeStreaks = [...cumulativeStreaks, streak];
 
-    if (isGolden || streak.isFever) {
+    if (isGolden) {
       session = await handleStreaksMove();
     }
     return session!;

--- a/src/pages/games/SnackGame/game/popup/PausePopup.ts
+++ b/src/pages/games/SnackGame/game/popup/PausePopup.ts
@@ -41,6 +41,7 @@ export class PausePopup extends BasePopup {
     try {
       this.setButtonsEnabled(false);
       await this.handleGameEnd();
+      this.setButtonsEnabled(true);
     } catch (error) {
       this.app.setError(error);
     }
@@ -50,6 +51,7 @@ export class PausePopup extends BasePopup {
     try {
       this.setButtonsEnabled(false);
       await this.handleGameResume();
+      this.setButtonsEnabled(true);
       this.app.dismissPopup();
     } catch (error) {
       this.app.setError(error);

--- a/src/pages/games/SnackGame/game/screen/BizGameScreen.ts
+++ b/src/pages/games/SnackGame/game/screen/BizGameScreen.ts
@@ -17,6 +17,7 @@ import {
   SNACK_TYPE,
   SnackGameMode,
   Streak,
+  StreakWithMeta,
   snackGameGetConfig,
 } from '../snackGame/SnackGameUtil';
 import { BeforeGameStart } from '../ui/BeforeGameStart';
@@ -55,7 +56,7 @@ export class BizGameScreen extends Container implements AppScreen {
     private app: SnackgameApplication,
     private getCurrentMode: () => SnackGameMode,
     private handleStreak: (
-      streak: Streak,
+      streak: StreakWithMeta,
       isGolden: boolean,
     ) => Promise<SnackGameVerify | SnackGameBizVerify>,
     private handleGameStart: () => Promise<SnackGameStart | SnackGameBizStart>,
@@ -94,6 +95,7 @@ export class BizGameScreen extends Container implements AppScreen {
     this.snackGame.onPop = this.onPop.bind(this);
     this.snackGame.onStreak = (data: Snack[]) => {
       let isGolden = false;
+      const occurredAt = new Date().toISOString();
 
       const streak = data.reduce((acc: Streak, snack) => {
         if (snack.type === SNACK_TYPE.GOLDEN) isGolden = true;
@@ -103,7 +105,10 @@ export class BizGameScreen extends Container implements AppScreen {
         return acc;
       }, []);
 
-      return this.handleStreak(streak, isGolden);
+      return this.handleStreak(
+        { coordinates: streak, isFever: false, occurredAt },
+        isGolden,
+      );
     };
     this.snackGame.onSnackGameBoardReset =
       this.onSnackGameBoardReset.bind(this);

--- a/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
+++ b/src/pages/games/SnackgameBiz/SnackGameBizBase.tsx
@@ -16,7 +16,7 @@ import { LobbyScreen } from '../SnackGame/game/screen/LobbyScreen';
 import { SnackgameApplication } from '../SnackGame/game/screen/SnackgameApplication';
 import {
   SnackGameMode,
-  Streak,
+  StreakWithMeta,
 } from '../SnackGame/game/snackGame/SnackGameUtil';
 
 type Props = {
@@ -68,7 +68,7 @@ const SnackGameBizBase = ({ replaceErrorHandler }: Props) => {
   // 게임 진행 관련 functions
   let session: SnackGameBizDefaultResponse | undefined;
   let sessionMode: SnackGameMode | undefined;
-  let cumulativeStreaks: Streak[] = [];
+  let cumulativeStreaks: StreakWithMeta[] = [];
 
   const handleGameStart = async () => {
     session = await gameApi.start();
@@ -85,7 +85,7 @@ const SnackGameBizBase = ({ replaceErrorHandler }: Props) => {
   };
 
   // TODO: 지금은 인자로 숫자를 사용하지만, '스트릭' VO를 만들어 사용하면 더 좋겠네요.
-  const handleStreak = async (streak: Streak, isGolden: boolean) => {
+  const handleStreak = async (streak: StreakWithMeta, isGolden: boolean) => {
     cumulativeStreaks = [...cumulativeStreaks, streak];
 
     if (isGolden) {

--- a/src/pages/games/SnackgameBiz/util/api.ts
+++ b/src/pages/games/SnackgameBiz/util/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { Streak } from '@pages/games/SnackGame/game/snackGame/SnackGameUtil';
+import { StreakWithMeta } from '@pages/games/SnackGame/game/snackGame/SnackGameUtil';
 
 import {
   SnackGameBizDefaultResponse,
@@ -39,7 +39,7 @@ export const createGameApiClient = () => {
     },
     verifyStreaks: async (
       sessionId: number,
-      streaks: Streak[],
+      streaks: StreakWithMeta[],
     ): Promise<SnackGameBizVerify> => {
       const { data } = await api.post(
         `/games/${GAME_ID}/${sessionId}/streaks`,


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 신규 피처

## 📋 변경 및 추가 사항

- 피버타임 중에도 기존과 동일하게 스트릭을 누적해서 보내도록 변경사항 [#388](https://github.com/snack-game/front/pull/388)을 revert 했습니다.

- `GameScreen`에서 아이템 선택/선택 해제 로직을 `selectItem()`/`releaseItem()`로 분리했습니다
  
  <img src="https://github.com/user-attachments/assets/63c4c701-6f9f-4db0-a420-60f2082fe512" height=500 />

- 스낵게임 Biz에는 아이템 기능이 없지만, 스트릭 검증 시 `StreaksRequest`라는 공통 스키마를 사용하고 있어서 
  요청 형식을 맞추기 위해 로직을 일부 수정했습니다

---

- `PausePopup`이 닫힐 때, 비활성화 된 내부 버튼을 다시 활성화하도록 코드를 추가했습니다

  - 별도로 브랜치 파기엔 작은 작업이라 요기 끼웠습니다

    | before | after |
    |:---:|:---:|
    |![before](https://github.com/user-attachments/assets/419214b8-fc94-4840-815e-5cbb3cd5fec4)|![after](https://github.com/user-attachments/assets/d187bfd0-8774-4d95-843f-aa0bd28d8e55)|
    |`PausePopup`을 처음 열 때만 버튼을 쓸 수 있는 문제||

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
