### PR TITLE
feat: 점검 시간 접근 차단을 위한 `MaintenanceGuard` 적용

### DIFF
--- a/public/locale/en/maintenance.json
+++ b/public/locale/en/maintenance.json
@@ -1,0 +1,9 @@
+{
+  "title": "Service Maintenance Notice",
+  "description": "System maintenance is in progress\nto improve our service.",
+  "maintenance_time": "Maintenance Time",
+  "maintenance_impact": "Service Impact",
+  "impact_details": "All services, including games, rankings, and profiles, will be unavailable.",
+  "notice": "Any updates will be announced",
+  "official_sns": "on our official SNS channels."
+}

--- a/public/locale/ko/maintenance.json
+++ b/public/locale/ko/maintenance.json
@@ -1,0 +1,9 @@
+{
+  "title": "서비스 점검 안내",
+  "description": "더 나은 서비스 제공을 위해\n시스템 점검을 진행하고 있습니다.",
+  "maintenance_time": "점검 일시",
+  "maintenance_impact": "점검 영향",
+  "impact_details": "게임, 랭킹, 프로필 페이지 등 서비스 전체 이용 불가",
+  "notice": "변동 사항이 있을 경우",
+  "official_sns": "공식 SNS를 통해 안내해 드리겠습니다"
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { PrivateRoute } from '@pages/PrivateRoute';
 import { resetUserState, userState } from '@utils/atoms/member.atom';
 
 import PATH from '@constants/path.constant';
+import { isInMaintenance } from '@constants/maintenance.constant';
 import useLocalStorage from '@hooks/useLocalStorage';
 
 import ServiceMaintenancePage from '@pages/maintenance/ServiceMaintenancePage';
@@ -69,7 +70,7 @@ const App = () => {
       }
     };
 
-    if (window.location.pathname.includes('biz')) return;
+    if (window.location.pathname.includes('biz') || isInMaintenance()) return;
     updateProfile();
   }, []);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,9 @@ import { resetUserState, userState } from '@utils/atoms/member.atom';
 import PATH from '@constants/path.constant';
 import useLocalStorage from '@hooks/useLocalStorage';
 
+import ServiceMaintenancePage from '@pages/maintenance/ServiceMaintenancePage';
+import { MaintenanceGuard } from '@pages/MaintenanceGuard';
+
 import '@utils/i18n/i18n';
 
 const MainPage = lazy(() => import('@pages/main/MainPage'));
@@ -73,65 +76,70 @@ const App = () => {
   return (
     <>
       <ErrorBoundary fallback={ErrorPage}>
-        <Suspense fallback={<Loading type={'page'} />}>
-          <Routes>
-            {/*Main*/}
-            <Route path={PATH.MAIN} element={<MainPage />} />
+        <MaintenanceGuard>
+          <Suspense fallback={<Loading type={'page'} />}>
+            <Routes>
+              {/*Main*/}
+              <Route path={PATH.MAIN} element={<MainPage />} />
 
-            {/*OAuth*/}
-            <Route path={PATH.OAUTH_SUCCESS} element={<OAuthPage />} />
-            <Route
-              path={PATH.OAUTH_FAILURE}
-              element={<ErrorPage message={'소셜 로그인에 실패했습니다.'} />}
-            />
+              {/*OAuth*/}
+              <Route path={PATH.OAUTH_SUCCESS} element={<OAuthPage />} />
+              <Route
+                path={PATH.OAUTH_FAILURE}
+                element={<ErrorPage message={'소셜 로그인에 실패했습니다.'} />}
+              />
 
-            <Route element={<GameLayout />}>
-              {/*Game*/}
-              <Route path={PATH.SNACK_GAME} element={<SnackGamePage />} />
-              <Route path={PATH.APPLE_GAME} element={<AppleGamePage />} />
+              {/*Maintenance*/}
+              <Route path={PATH.MAINTENANCE} element={<ServiceMaintenancePage />} />
 
-              {/*Ranking*/}
-              <Route path={PATH.SNACK_GAME_RANKING} element={<RankingPage />} />
+              <Route element={<GameLayout />}>
+                {/*Game*/}
+                <Route path={PATH.SNACK_GAME} element={<SnackGamePage />} />
+                <Route path={PATH.APPLE_GAME} element={<AppleGamePage />} />
+
+                {/*Ranking*/}
+                <Route path={PATH.SNACK_GAME_RANKING} element={<RankingPage />} />
+
+                <Route element={<PrivateRoute />}>
+                  {/* User */}
+                  <Route path={PATH.USER} element={<UserPage />} />
+                </Route>
+              </Route>
+
+              <Route>
+                {/*Game*/}
+                <Route
+                  path={PATH.SNACK_GAME_BIZ}
+                  element={<SnackGameBizPage />}
+                />
+              </Route>
 
               <Route element={<PrivateRoute />}>
-                {/* User */}
-                <Route path={PATH.USER} element={<UserPage />} />
+                {/*Setting*/}
+                <Route path={PATH.SETTING} element={<SettingPage />} />
+
+                {/* Withdraw */}
+                <Route path={PATH.WITHDRAW} element={<WithdrawPage />} />
+
+                {/* Notices */}
+                <Route path={PATH.NOTICE} element={<NoticePage />} />
               </Route>
-            </Route>
 
-            <Route>
-              {/*Game*/}
+              {/* Policy */}
+              <Route path={PATH.POLICY} element={<PolicyPage />} />
+
+              {/*Error*/}
               <Route
-                path={PATH.SNACK_GAME_BIZ}
-                element={<SnackGameBizPage />}
+                path={PATH.NOT_FOUND_ERROR}
+                element={
+                  <ErrorPage error={new Error('존재하지 않는 페이지입니다!')} />
+                }
               />
-            </Route>
-
-            <Route element={<PrivateRoute />}>
-              {/*Setting*/}
-              <Route path={PATH.SETTING} element={<SettingPage />} />
-
-              {/* Withdraw */}
-              <Route path={PATH.WITHDRAW} element={<WithdrawPage />} />
-
-              {/* Notices */}
-              <Route path={PATH.NOTICE} element={<NoticePage />} />
-            </Route>
-
-            {/* Policy */}
-            <Route path={PATH.POLICY} element={<PolicyPage />} />
-
-            {/*Error*/}
-            <Route
-              path={PATH.NOT_FOUND_ERROR}
-              element={
-                <ErrorPage error={new Error('존재하지 않는 페이지입니다!')} />
-              }
-            />
-          </Routes>
-          <Modal />
-        </Suspense>
-        <Toast />
+            </Routes>
+            <Modal />
+          </Suspense>
+          <Toast />
+        </MaintenanceGuard>
       </ErrorBoundary>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,15 +9,14 @@ import Loading from '@components/Loading/Loading';
 import Modal from '@components/Modal/Modal';
 import Toast from '@components/Toast/Toast';
 import GameLayout from '@pages/GameLayout';
+import ServiceMaintenancePage from '@pages/maintenance/ServiceMaintenancePage';
+import { MaintenanceGuard } from '@pages/MaintenanceGuard';
 import { PrivateRoute } from '@pages/PrivateRoute';
 import { resetUserState, userState } from '@utils/atoms/member.atom';
 
-import PATH from '@constants/path.constant';
 import { isInMaintenance } from '@constants/maintenance.constant';
+import PATH from '@constants/path.constant';
 import useLocalStorage from '@hooks/useLocalStorage';
-
-import ServiceMaintenancePage from '@pages/maintenance/ServiceMaintenancePage';
-import { MaintenanceGuard } from '@pages/MaintenanceGuard';
 
 import '@utils/i18n/i18n';
 
@@ -91,7 +90,10 @@ const App = () => {
               />
 
               {/*Maintenance*/}
-              <Route path={PATH.MAINTENANCE} element={<ServiceMaintenancePage />} />
+              <Route
+                path={PATH.MAINTENANCE}
+                element={<ServiceMaintenancePage />}
+              />
 
               <Route element={<GameLayout />}>
                 {/*Game*/}
@@ -99,7 +101,10 @@ const App = () => {
                 <Route path={PATH.APPLE_GAME} element={<AppleGamePage />} />
 
                 {/*Ranking*/}
-                <Route path={PATH.SNACK_GAME_RANKING} element={<RankingPage />} />
+                <Route
+                  path={PATH.SNACK_GAME_RANKING}
+                  element={<RankingPage />}
+                />
 
                 <Route element={<PrivateRoute />}>
                   {/* User */}

--- a/src/constants/maintenance.constant.ts
+++ b/src/constants/maintenance.constant.ts
@@ -1,0 +1,6 @@
+export const MAINTENANCE_START = new Date('2026-02-01T00:00:00+09:00');
+export const MAINTENANCE_END = new Date('2026-02-01T23:59:00+09:00');
+
+export const isInMaintenance = (now = new Date()) => {
+  return now >= MAINTENANCE_START && now <= MAINTENANCE_END;
+}

--- a/src/constants/maintenance.constant.ts
+++ b/src/constants/maintenance.constant.ts
@@ -1,6 +1,6 @@
-export const MAINTENANCE_START = new Date('2026-02-09T21:00:00+09:00');
+export const MAINTENANCE_START = new Date('2026-02-09T11:00:00+09:00');
 export const MAINTENANCE_END = new Date('2026-02-09T23:59:00+09:00');
 
 export const isInMaintenance = (now = new Date()) => {
   return now >= MAINTENANCE_START && now <= MAINTENANCE_END;
-}
+};

--- a/src/constants/maintenance.constant.ts
+++ b/src/constants/maintenance.constant.ts
@@ -1,5 +1,5 @@
-export const MAINTENANCE_START = new Date('2026-02-01T00:00:00+09:00');
-export const MAINTENANCE_END = new Date('2026-02-01T23:59:00+09:00');
+export const MAINTENANCE_START = new Date('2026-02-09T21:00:00+09:00');
+export const MAINTENANCE_END = new Date('2026-02-09T23:59:00+09:00');
 
 export const isInMaintenance = (now = new Date()) => {
   return now >= MAINTENANCE_START && now <= MAINTENANCE_END;

--- a/src/constants/maintenance.constant.ts
+++ b/src/constants/maintenance.constant.ts
@@ -1,4 +1,4 @@
-export const MAINTENANCE_START = new Date('2026-02-09T11:00:00+09:00');
+export const MAINTENANCE_START = new Date('2026-02-09T20:30:00+09:00');
 export const MAINTENANCE_END = new Date('2026-02-09T23:59:00+09:00');
 
 export const isInMaintenance = (now = new Date()) => {

--- a/src/constants/path.constant.ts
+++ b/src/constants/path.constant.ts
@@ -11,6 +11,7 @@ const PATH = {
   POLICY: '/policy',
   WITHDRAW: '/user/setting/withdraw',
   NOTICE: '/user/setting/notices',
+  MAINTENANCE: '/maintenance',
 
   SNACK_GAME: '/snack-game',
   SNACK_GAME_BIZ: '/snack-game/biz',
@@ -26,6 +27,8 @@ const PATH = {
   ONE_LINK: 'https://snackgame.onelink.me/MHW6/github',
 
   NOTICE_RSS: 'https://notice.snackga.me/index.xml',
+
+  INSTAGRAM: 'https://www.instagram.com/snackga._.me/',
 
   GOOGLE: '/oauth2/authorization/google',
   KAKAO: '/oauth2/authorization/kakao',

--- a/src/pages/MaintenanceGuard.tsx
+++ b/src/pages/MaintenanceGuard.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+import { useLocation, Navigate } from 'react-router-dom';
+import { isInMaintenance } from '@constants/maintenance.constant';
+import PATH from '@constants/path.constant';
+
+
+export const MaintenanceGuard = ({ children }: { children: ReactNode }) => {
+  const location = useLocation();
+
+  const isWhitelisted = (pathname: string): boolean => {
+    return (
+      pathname === PATH.MAIN ||
+      pathname === PATH.MAINTENANCE
+    );
+  };
+
+  if (isInMaintenance() && !isWhitelisted(location.pathname)) {
+    return <Navigate to={PATH.MAINTENANCE} replace />;
+  }
+
+  return <>{children}</>;
+};

--- a/src/pages/MaintenanceGuard.tsx
+++ b/src/pages/MaintenanceGuard.tsx
@@ -3,7 +3,6 @@ import { useLocation, Navigate } from 'react-router-dom';
 import { isInMaintenance } from '@constants/maintenance.constant';
 import PATH from '@constants/path.constant';
 
-
 export const MaintenanceGuard = ({ children }: { children: ReactNode }) => {
   const location = useLocation();
 

--- a/src/pages/MaintenanceGuard.tsx
+++ b/src/pages/MaintenanceGuard.tsx
@@ -1,17 +1,15 @@
 import { ReactNode } from 'react';
 import { useLocation, Navigate } from 'react-router-dom';
+
 import { isInMaintenance } from '@constants/maintenance.constant';
 import PATH from '@constants/path.constant';
 
+const isWhitelisted = (pathname: string): boolean => {
+  return pathname === PATH.MAIN || pathname === PATH.MAINTENANCE;
+};
+
 export const MaintenanceGuard = ({ children }: { children: ReactNode }) => {
   const location = useLocation();
-
-  const isWhitelisted = (pathname: string): boolean => {
-    return (
-      pathname === PATH.MAIN ||
-      pathname === PATH.MAINTENANCE
-    );
-  };
 
   if (isInMaintenance() && !isWhitelisted(location.pathname)) {
     return <Navigate to={PATH.MAINTENANCE} replace />;

--- a/src/pages/maintenance/ServiceMaintenancePage.tsx
+++ b/src/pages/maintenance/ServiceMaintenancePage.tsx
@@ -1,0 +1,72 @@
+import { Helmet } from 'react-helmet-async';
+
+import MainAvifImage from '@assets/images/main.avif';
+import MainWebpImage from '@assets/images/main.webp';
+import ImageWithFallback from '@components/ImageWithFallback/ImageWithFallback';
+import Spacing from '@components/Spacing/Spacing';
+
+import PATH from '@constants/path.constant';
+import { MAINTENANCE_START, MAINTENANCE_END } from '@constants/maintenance.constant';
+
+const ServiceMaintenancePage = () => {
+  return (
+    <>
+      <Helmet>
+        <title>Snack Game || 점검 중</title>
+      </Helmet>
+      <div className="flex min-h-screen flex-col items-center justify-center bg-primary-light p-6">
+        <div className="flex flex-col items-center">
+          <ImageWithFallback
+            sources={[
+              { srcSet: MainAvifImage, type: 'avif' },
+              { srcSet: MainWebpImage, type: 'webp' },
+            ]}
+            src={MainWebpImage}
+            alt="Snack Game Character"
+            className="h-48 w-48"
+          />
+
+          <div className="text-center">
+            <h1 className="mb-4 text-2xl font-bold text-primary-deep-dark">
+              서비스 점검 안내
+            </h1>
+            <p className="whitespace-pre-line text-base text-gray-600">
+              더 나은 서비스 제공을 위해{'\n'}시스템 점검을 진행하고 있습니다.
+            </p>
+          </div>
+
+          <Spacing size={2} />
+
+          <div className="w-full max-w-md rounded-lg border bg-white p-6">
+            <ul className="space-y-3 text-left">
+              <li className="text-sm text-gray-700">
+                <span className="font-semibold">점검 일시:</span>{' '}
+                {MAINTENANCE_START && MAINTENANCE_END
+                  && `${MAINTENANCE_START.toLocaleString()} ~ ${MAINTENANCE_END.toLocaleString()} (KST)`
+                }
+              </li>
+              <li className="text-sm text-gray-700">
+                <span className="font-semibold">점검 영향:</span> 게임, 랭킹,
+                프로필 페이지 등 서비스 전체 이용 불가
+              </li>
+              <li className="text-sm text-gray-500">
+                * 변동 사항이 있을 경우{' '}
+                <a
+                  href={PATH.INSTAGRAM}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className=" text-primary underline"
+                >
+                  공식 SNS
+                </a>
+                를 통해 안내해 드리겠습니다.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ServiceMaintenancePage;

--- a/src/pages/maintenance/ServiceMaintenancePage.tsx
+++ b/src/pages/maintenance/ServiceMaintenancePage.tsx
@@ -1,4 +1,5 @@
 import { Helmet } from 'react-helmet-async';
+import { Navigate } from 'react-router-dom';
 
 import MainAvifImage from '@assets/images/main.avif';
 import MainWebpImage from '@assets/images/main.webp';
@@ -6,9 +7,13 @@ import ImageWithFallback from '@components/ImageWithFallback/ImageWithFallback';
 import Spacing from '@components/Spacing/Spacing';
 
 import PATH from '@constants/path.constant';
-import { MAINTENANCE_START, MAINTENANCE_END } from '@constants/maintenance.constant';
+import { MAINTENANCE_START, MAINTENANCE_END, isInMaintenance } from '@constants/maintenance.constant';
 
 const ServiceMaintenancePage = () => {
+  if (!isInMaintenance()) {
+    return <Navigate to={PATH.MAIN} replace />;
+  }
+
   return (
     <>
       <Helmet>

--- a/src/pages/maintenance/ServiceMaintenancePage.tsx
+++ b/src/pages/maintenance/ServiceMaintenancePage.tsx
@@ -41,9 +41,7 @@ const ServiceMaintenancePage = () => {
             <ul className="space-y-3 text-left">
               <li className="text-sm text-gray-700">
                 <span className="font-semibold">점검 일시:</span>{' '}
-                {MAINTENANCE_START && MAINTENANCE_END
-                  && `${MAINTENANCE_START.toLocaleString()} ~ ${MAINTENANCE_END.toLocaleString()} (KST)`
-                }
+                {`${MAINTENANCE_START.toLocaleString()} ~ ${MAINTENANCE_END.toLocaleString()} (KST)`}
               </li>
               <li className="text-sm text-gray-700">
                 <span className="font-semibold">점검 영향:</span> 게임, 랭킹,

--- a/src/pages/maintenance/ServiceMaintenancePage.tsx
+++ b/src/pages/maintenance/ServiceMaintenancePage.tsx
@@ -6,8 +6,12 @@ import MainWebpImage from '@assets/images/main.webp';
 import ImageWithFallback from '@components/ImageWithFallback/ImageWithFallback';
 import Spacing from '@components/Spacing/Spacing';
 
+import {
+  MAINTENANCE_START,
+  MAINTENANCE_END,
+  isInMaintenance,
+} from '@constants/maintenance.constant';
 import PATH from '@constants/path.constant';
-import { MAINTENANCE_START, MAINTENANCE_END, isInMaintenance } from '@constants/maintenance.constant';
 
 const ServiceMaintenancePage = () => {
   if (!isInMaintenance()) {
@@ -46,7 +50,7 @@ const ServiceMaintenancePage = () => {
             <ul className="space-y-3 text-left">
               <li className="text-sm text-gray-700">
                 <span className="font-semibold">점검 일시:</span>{' '}
-                {`${MAINTENANCE_START.toLocaleString()} ~ ${MAINTENANCE_END.toLocaleString()} (KST)`}
+                {`${MAINTENANCE_START.toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' })} ~ ${MAINTENANCE_END.toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' })} (KST)`}
               </li>
               <li className="text-sm text-gray-700">
                 <span className="font-semibold">점검 영향:</span> 게임, 랭킹,

--- a/src/pages/maintenance/ServiceMaintenancePage.tsx
+++ b/src/pages/maintenance/ServiceMaintenancePage.tsx
@@ -1,4 +1,5 @@
 import { Helmet } from 'react-helmet-async';
+import { useTranslation } from 'react-i18next';
 import { Navigate } from 'react-router-dom';
 
 import MainAvifImage from '@assets/images/main.avif';
@@ -14,6 +15,8 @@ import {
 import PATH from '@constants/path.constant';
 
 const ServiceMaintenancePage = () => {
+  const { t } = useTranslation('maintenance');
+
   if (!isInMaintenance()) {
     return <Navigate to={PATH.MAIN} replace />;
   }
@@ -37,10 +40,10 @@ const ServiceMaintenancePage = () => {
 
           <div className="text-center">
             <h1 className="mb-4 text-2xl font-bold text-primary-deep-dark">
-              서비스 점검 안내
+              {t('title')}
             </h1>
             <p className="whitespace-pre-line text-base text-gray-600">
-              더 나은 서비스 제공을 위해{'\n'}시스템 점검을 진행하고 있습니다.
+              {t('description')}
             </p>
           </div>
 
@@ -49,24 +52,25 @@ const ServiceMaintenancePage = () => {
           <div className="w-full max-w-md rounded-lg border bg-white p-6">
             <ul className="space-y-3 text-left">
               <li className="text-sm text-gray-700">
-                <span className="font-semibold">점검 일시:</span>{' '}
+                <span className="font-semibold">{t('maintenance_time')}:</span>{' '}
                 {`${MAINTENANCE_START.toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' })} ~ ${MAINTENANCE_END.toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' })} (KST)`}
               </li>
               <li className="text-sm text-gray-700">
-                <span className="font-semibold">점검 영향:</span> 게임, 랭킹,
-                프로필 페이지 등 서비스 전체 이용 불가
+                <span className="font-semibold">
+                  {t('maintenance_impact')}:
+                </span>{' '}
+                {t('impact_details')}
               </li>
               <li className="text-sm text-gray-500">
-                * 변동 사항이 있을 경우{' '}
+                * {t('notice')}{' '}
                 <a
                   href={PATH.INSTAGRAM}
                   target="_blank"
                   rel="noopener noreferrer"
                   className=" text-primary underline"
                 >
-                  공식 SNS
+                  {t('official_sns')}
                 </a>
-                를 통해 안내해 드리겠습니다.
               </li>
             </ul>
           </div>

--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -9,7 +9,15 @@ i18next
   .use(initReactI18next)
   .use(HttpBackend)
   .init({
-    ns: ['game', 'landing', 'ranking', 'setting', 'translation', 'user'],
+    ns: [
+      'game',
+      'landing',
+      'ranking',
+      'setting',
+      'translation',
+      'user',
+      'maintenance',
+    ],
     fallbackLng: 'ko',
     backend: {
       loadPath: '/locale/{{lng}}/{{ns}}.json',
@@ -29,7 +37,7 @@ i18next
         'subdomain',
       ],
       caches: ['localStorage'],
-      convertDetectedLanguage: (lng) => lng.split('-')[0]
+      convertDetectedLanguage: (lng) => lng.split('-')[0],
     },
   });
 


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 신규 피처

## 📋 변경 및 추가 사항

- `MaintenanceGuard`를 적용해 점검 시간에는 페이지 접근이 불가하게 막았습니다.
  - 점검 중에 접근 시 점검 페이지로 이동합니다 (`/maintenance`)
  - 랜딩 페이지는 예외적으로 접근 허용~~!

- `maintenance.constants.ts`에 점검 시간 상수 / 현재 점검 여부 확인용 함수를 추가했습니다

| 점검 중에는 점검 페이지로 이동 | 점검 아닐 때 `/maintenance` 접근 불가 |
|:---:|:---:|
|![점검중](https://github.com/user-attachments/assets/a7c73638-e1cf-4ef4-8220-fccfe487e490)|![점검아님~~!](https://github.com/user-attachments/assets/96713981-0733-4860-b123-3d830a4e44de)|


## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
