### PR TITLE
fix(ItemBar): 아이템 버튼 초기화 로직 개선

### DIFF
--- a/src/pages/games/SnackGame/game/ui/ItemBar.ts
+++ b/src/pages/games/SnackGame/game/ui/ItemBar.ts
@@ -27,6 +27,9 @@ export class ItemBar extends Container {
   }
 
   public setup(items: ItemButtonOptions[]) {
+    this.buttons.forEach((button) => button.destroy());
+    this.buttons = [];
+
     items.forEach(({ type, count, onUse }, idx) => {
       const button = new ItemButton({
         type,

--- a/src/pages/games/SnackGame/game/ui/ItemBar.ts
+++ b/src/pages/games/SnackGame/game/ui/ItemBar.ts
@@ -27,7 +27,7 @@ export class ItemBar extends Container {
   }
 
   public setup(items: ItemButtonOptions[]) {
-    this.buttons.forEach((button) => button.destroy());
+    this.buttons.forEach((button) => button.destroy({ children: true }));
     this.buttons = [];
 
     items.forEach(({ type, count, onUse }, idx) => {


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 이슈 대응

## 📋 변경 및 추가 사항

- 아이템 버튼이 여러 개 그려지는 문제가 있었습니다

  > 재현 방법: 게스트 플레이 -> 게임 종료 후 로그인 -> 재시작
 
  <img width="378" height="472" alt="스크린샷 2026-03-31 오후 9 55 51" src="https://github.com/user-attachments/assets/9d14c912-2c7d-42a5-ae28-197ab88c4cd6" />

  게스트 플레이일 때 그려졌던 아이템 버튼이 남아있음..!!
  
- `ItemBar`에서 아이템 버튼을 생성할 때 기존 버튼을 정리하는 로직을 추가했어용

## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
