### PR TITLE
refactor(useNoticeModal): 만료 시점 관리를 위한 expireDate 추가

### DIFF
--- a/src/pages/games/SnackGame/game/hook/useNoticeModal.tsx
+++ b/src/pages/games/SnackGame/game/hook/useNoticeModal.tsx
@@ -6,8 +6,10 @@ import ImageWithFallback from '@components/ImageWithFallback/ImageWithFallback';
 import { KEY_LAST_NOTICE_INFO } from '@constants/localStorage.constant';
 import useModal from '@hooks/useModal';
 
-// notice_YYYYMMDD_keyword(_version)
-const CURRENT_ID = 'notice_20250710_bomb';
+const NOTICE_CONFIG = {
+  id: 'notice_2025-07-10_bomb',
+  expireDate: '2025-07-17T23:59:59+09:00',
+} as const;
 
 const Notice = () => {
   const { closeModal } = useModal();
@@ -18,7 +20,7 @@ const Notice = () => {
     localStorage.setItem(
       KEY_LAST_NOTICE_INFO,
       JSON.stringify({
-        id: CURRENT_ID,
+        id: NOTICE_CONFIG.id,
         hideUntil: new Date(Date.now() + ONE_DAY),
       }),
     );
@@ -63,14 +65,19 @@ const Notice = () => {
 export const useNoticeModal = () => {
   const { openModal } = useModal();
 
+  const isNoticeExpired = () => {
+    return new Date() > new Date(NOTICE_CONFIG.expireDate);
+  };
+
   const isNoticeHidden = () => {
     const lastNotice = localStorage.getItem(KEY_LAST_NOTICE_INFO);
     const { id, hideUntil } = lastNotice ? JSON.parse(lastNotice) : {};
 
-    return id === CURRENT_ID && new Date(hideUntil) > new Date();
+    return id === NOTICE_CONFIG.id && new Date(hideUntil) > new Date();
   };
 
   const openNoticeModal = () => {
+    if (isNoticeExpired()) return;
     if (isNoticeHidden()) return;
 
     openModal({


### PR DESCRIPTION
## 💻 개요

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
<!-- #(이슈번호)를 통해 이슈를 명시해 주세요 -->

- 리팩토링

## 📋 변경 및 추가 사항

- 기존 `useNoticeModal`은 공지가 없는 상태를 표현하는 코드가 없었어요
  - 공지가 없을 때는 `CURRENT_ID`를 빈 문자열로 두는지 null로 바꾸는지 판단할 수가 X

- 공지 내릴 때마다 코드 수정하려면 귀찮으니까. 만료 시점을 추가했습니다
  - 기존 `CURRENT_ID`를 포함하는 객체를 만들었습니다
  
    ```js
    const NOTICE_CONFIG = {
      id: 'notice_2025-07-10_bomb', // 공지 id
      expireDate: '2025-07-17T23:59:59+09:00', // 만료 시점
    } as const;
    ```

  - `useNoticeModal`에서 만료 시점이 지난 공지는 노출하지 않게 했습니다
  
    ```js
      export const useNoticeModal = () => {
        const isNoticeExpired = () => { // 추가된 함수
          return new Date() > new Date(NOTICE_CONFIG.expireDate);
        };
      
        const openNoticeModal = () => {
          if (isNoticeExpired()) return; // 요기서 호출됨
        };
      
        return { openNoticeModal };
      };
    ```

- 원래 뜨던 폭탄 공지는 2025-07-17로 만료일을 설정해서 이제 안 뜨게 됐습니다

  https://github.com/user-attachments/assets/c1743ffc-ca0c-4c25-92a7-1d9dcd9a1759


## 💬 To. 리뷰어

<!-- 예: # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
<!-- 예: react-query 버전업을 하는건 어떨까요~~~ -->
<!-- 등등 진행하며 들었던 의문이나 의논하고 싶은 부분 -->
